### PR TITLE
move file api to client

### DIFF
--- a/src/components/molecules/FilesInput/index.tsx
+++ b/src/components/molecules/FilesInput/index.tsx
@@ -3,7 +3,7 @@ import { useField } from 'formik'
 import { toast } from 'react-toastify'
 import FileInfo from './Info'
 import FileInput from './Input'
-import { getFileInfo } from '../../../utils'
+import getFileInfo from '../../../utils/file'
 import { InputProps } from '../../atoms/Input'
 
 interface Values {

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -1,6 +1,7 @@
-import { NowRequest, NowResponse } from '@now/node'
 import axios, { AxiosResponse } from 'axios'
 import { IncomingHttpHeaders } from 'http'
+import { toast } from 'react-toastify'
+import { File as FileMetadata } from '@oceanprotocol/lib/dist/node/ddo/interfaces/File'
 
 interface ResponseResult {
   contentLength?: string
@@ -60,13 +61,19 @@ async function checkUrl(url: string): Promise<FileResponse> {
   }
 }
 
-export default async (req: NowRequest, res: NowResponse) => {
-  switch (req.method) {
-    case 'POST':
-      res.status(200).json(await checkUrl(req.body.url))
-      break
-    default:
-      res.setHeader('Allow', ['POST'])
-      res.status(405).end(`Method ${req.method} Not Allowed`)
+export default async function getFileInfo(url: string): Promise<FileMetadata> {
+  const response = await checkUrl(url)
+
+  if (response.status === 'error') {
+    toast.error(response.message)
+    return
+  }
+
+  const { contentLength, contentType } = response.result
+
+  return {
+    contentLength,
+    contentType: contentType || '', // need to do that cause squid.js File interface requires contentType
+    url
   }
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -51,27 +51,6 @@ export function toStringNoMS(date: Date): string {
   return date.toISOString().replace(/\.[0-9]{3}Z/, 'Z')
 }
 
-export async function getFileInfo(url: string): Promise<FileMetadata> {
-  const response: AxiosResponse = await axios({
-    method: 'POST',
-    url: '/api/file',
-    data: { url }
-  })
-
-  if (response.status > 299 || !response.data.result) {
-    toast.error('Could not connect to File API')
-    return
-  }
-
-  const { contentLength, contentType } = response.data.result
-
-  return {
-    contentLength,
-    contentType: contentType || '', // need to do that cause squid.js File interface requires contentType
-    url
-  }
-}
-
 export async function fetchData(url: string): Promise<Axios> {
   try {
     const response = await axios(url)

--- a/tests/unit/api/file.test.tsx
+++ b/tests/unit/api/file.test.tsx
@@ -1,5 +1,5 @@
 import { createMocks } from 'node-mocks-http'
-import apiRoute from '../../../api/file'
+import apiRoute from '../../../src/utils/file'
 
 describe('/api/file', () => {
   test('responds 405 to GET', async () => {


### PR DESCRIPTION
Not sure that will work, think this was the reason to use a proxy for this. 

On first try after refactor in this PR I get:

<img width="1376" alt="Screen Shot 2020-07-16 at 15 50 49" src="https://user-images.githubusercontent.com/90316/87679155-20e56c80-c77c-11ea-8c0a-39e1619c4a87.png">
