### PR TITLE
dynamic loading of provider packages

### DIFF
--- a/src/utils/wallet.ts
+++ b/src/utils/wallet.ts
@@ -11,10 +11,10 @@ const web3ModalTheme = {
   hover: 'var(--brand-grey-dimmed)'
 }
 
-const WalletConnectProvider = loadable(() =>
-  import('@walletconnect/web3-provider')
+const WalletConnectProvider = loadable(
+  () => import('@walletconnect/web3-provider') as any
 )
-const Torus = loadable(() => import('@toruslabs/torus-embed'))
+const Torus = loadable(() => import('@toruslabs/torus-embed') as any)
 
 const providerOptions = {
   walletconnect: {


### PR DESCRIPTION
Code splitting our way out of this provider packages problem. We kinda need the `OceanProvider` during SSR builds too, otherwise we have to put in fallbacks every time we access it in all the components.

As before, the solution is to somehow dynamically load all the provider packages on client-side only. With `@loadable/component` this seems to be possible