### PR TITLE
Burner wallet fallback

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5717,6 +5717,270 @@
         }
       }
     },
+    "@truffle/hdwallet-provider": {
+      "version": "1.0.44",
+      "resolved": "https://registry.npmjs.org/@truffle/hdwallet-provider/-/hdwallet-provider-1.0.44.tgz",
+      "integrity": "sha512-pStsF5me3cxthf6dVjuQV08CzssUneURw9ZZCDknFZIq/kofWuk710VnmSIhDBcT2iSxGzemy0hIuP+3MG3fYQ==",
+      "requires": {
+        "@trufflesuite/web3-provider-engine": "15.0.13-1",
+        "@types/web3": "^1.0.20",
+        "any-promise": "^1.3.0",
+        "bindings": "^1.5.0",
+        "ethereum-cryptography": "^0.1.3",
+        "ethereum-protocol": "^1.0.1",
+        "ethereumjs-tx": "^1.0.0",
+        "ethereumjs-util": "^6.1.0",
+        "ethereumjs-wallet": "^0.6.3",
+        "source-map-support": "^0.5.19"
+      },
+      "dependencies": {
+        "ethereum-common": {
+          "version": "0.0.18",
+          "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.0.18.tgz",
+          "integrity": "sha1-L9w1dvIykDNYl26znaeDIT/5Uj8="
+        },
+        "ethereumjs-tx": {
+          "version": "1.3.7",
+          "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-1.3.7.tgz",
+          "integrity": "sha512-wvLMxzt1RPhAQ9Yi3/HKZTn0FZYpnsmQdbKYfUUpi4j1SEIcbkd9tndVjcPrufY3V7j2IebOpC00Zp2P/Ay2kA==",
+          "requires": {
+            "ethereum-common": "^0.0.18",
+            "ethereumjs-util": "^5.0.0"
+          },
+          "dependencies": {
+            "ethereumjs-util": {
+              "version": "5.2.1",
+              "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
+              "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
+              "requires": {
+                "bn.js": "^4.11.0",
+                "create-hash": "^1.1.2",
+                "elliptic": "^6.5.2",
+                "ethereum-cryptography": "^0.1.3",
+                "ethjs-util": "^0.1.3",
+                "rlp": "^2.0.0",
+                "safe-buffer": "^5.1.1"
+              }
+            }
+          }
+        }
+      }
+    },
+    "@trufflesuite/eth-json-rpc-filters": {
+      "version": "4.1.2-1",
+      "resolved": "https://registry.npmjs.org/@trufflesuite/eth-json-rpc-filters/-/eth-json-rpc-filters-4.1.2-1.tgz",
+      "integrity": "sha512-/MChvC5dw2ck9NU1cZmdovCz2VKbOeIyR4tcxDvA5sT+NaL0rA2/R5U0yI7zsbo1zD+pgqav77rQHTzpUdDNJQ==",
+      "requires": {
+        "@trufflesuite/eth-json-rpc-middleware": "^4.4.2-0",
+        "await-semaphore": "^0.1.3",
+        "eth-query": "^2.1.2",
+        "json-rpc-engine": "^5.1.3",
+        "lodash.flatmap": "^4.5.0",
+        "safe-event-emitter": "^1.0.1"
+      }
+    },
+    "@trufflesuite/eth-json-rpc-infura": {
+      "version": "4.0.3-0",
+      "resolved": "https://registry.npmjs.org/@trufflesuite/eth-json-rpc-infura/-/eth-json-rpc-infura-4.0.3-0.tgz",
+      "integrity": "sha512-xaUanOmo0YLqRsL0SfXpFienhdw5bpQ1WEXxMTRi57az4lwpZBv4tFUDvcerdwJrxX9wQqNmgUgd1BrR01dumw==",
+      "requires": {
+        "@trufflesuite/eth-json-rpc-middleware": "^4.4.2-1",
+        "cross-fetch": "^2.1.1",
+        "eth-json-rpc-errors": "^1.0.1",
+        "json-rpc-engine": "^5.1.3"
+      },
+      "dependencies": {
+        "eth-json-rpc-errors": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/eth-json-rpc-errors/-/eth-json-rpc-errors-1.1.1.tgz",
+          "integrity": "sha512-WT5shJ5KfNqHi9jOZD+ID8I1kuYWNrigtZat7GOQkvwo99f8SzAVaEcWhJUv656WiZOAg3P1RiJQANtUmDmbIg==",
+          "requires": {
+            "fast-safe-stringify": "^2.0.6"
+          }
+        }
+      }
+    },
+    "@trufflesuite/eth-json-rpc-middleware": {
+      "version": "4.4.2-1",
+      "resolved": "https://registry.npmjs.org/@trufflesuite/eth-json-rpc-middleware/-/eth-json-rpc-middleware-4.4.2-1.tgz",
+      "integrity": "sha512-iEy9H8ja7/8aYES5HfrepGBKU9n/Y4OabBJEklVd/zIBlhCCBAWBqkIZgXt11nBXO/rYAeKwYuE3puH3ByYnLA==",
+      "requires": {
+        "@trufflesuite/eth-sig-util": "^1.4.2",
+        "btoa": "^1.2.1",
+        "clone": "^2.1.1",
+        "eth-json-rpc-errors": "^1.0.1",
+        "eth-query": "^2.1.2",
+        "ethereumjs-block": "^1.6.0",
+        "ethereumjs-tx": "^1.3.7",
+        "ethereumjs-util": "^5.1.2",
+        "ethereumjs-vm": "^2.6.0",
+        "fetch-ponyfill": "^4.0.0",
+        "json-rpc-engine": "^5.1.3",
+        "json-stable-stringify": "^1.0.1",
+        "pify": "^3.0.0",
+        "safe-event-emitter": "^1.0.1"
+      },
+      "dependencies": {
+        "eth-json-rpc-errors": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/eth-json-rpc-errors/-/eth-json-rpc-errors-1.1.1.tgz",
+          "integrity": "sha512-WT5shJ5KfNqHi9jOZD+ID8I1kuYWNrigtZat7GOQkvwo99f8SzAVaEcWhJUv656WiZOAg3P1RiJQANtUmDmbIg==",
+          "requires": {
+            "fast-safe-stringify": "^2.0.6"
+          }
+        },
+        "ethereum-common": {
+          "version": "0.0.18",
+          "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.0.18.tgz",
+          "integrity": "sha1-L9w1dvIykDNYl26znaeDIT/5Uj8="
+        },
+        "ethereumjs-tx": {
+          "version": "1.3.7",
+          "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-1.3.7.tgz",
+          "integrity": "sha512-wvLMxzt1RPhAQ9Yi3/HKZTn0FZYpnsmQdbKYfUUpi4j1SEIcbkd9tndVjcPrufY3V7j2IebOpC00Zp2P/Ay2kA==",
+          "requires": {
+            "ethereum-common": "^0.0.18",
+            "ethereumjs-util": "^5.0.0"
+          }
+        },
+        "ethereumjs-util": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
+          "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
+          "requires": {
+            "bn.js": "^4.11.0",
+            "create-hash": "^1.1.2",
+            "elliptic": "^6.5.2",
+            "ethereum-cryptography": "^0.1.3",
+            "ethjs-util": "^0.1.3",
+            "rlp": "^2.0.0",
+            "safe-buffer": "^5.1.1"
+          }
+        }
+      }
+    },
+    "@trufflesuite/eth-sig-util": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@trufflesuite/eth-sig-util/-/eth-sig-util-1.4.2.tgz",
+      "integrity": "sha512-+GyfN6b0LNW77hbQlH3ufZ/1eCON7mMrGym6tdYf7xiNw9Vv3jBO72bmmos1EId2NgBvPMhmYYm6DSLQFTmzrA==",
+      "requires": {
+        "ethereumjs-abi": "^0.6.8",
+        "ethereumjs-util": "^5.1.1"
+      },
+      "dependencies": {
+        "ethereumjs-util": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
+          "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
+          "requires": {
+            "bn.js": "^4.11.0",
+            "create-hash": "^1.1.2",
+            "elliptic": "^6.5.2",
+            "ethereum-cryptography": "^0.1.3",
+            "ethjs-util": "^0.1.3",
+            "rlp": "^2.0.0",
+            "safe-buffer": "^5.1.1"
+          }
+        }
+      }
+    },
+    "@trufflesuite/web3-provider-engine": {
+      "version": "15.0.13-1",
+      "resolved": "https://registry.npmjs.org/@trufflesuite/web3-provider-engine/-/web3-provider-engine-15.0.13-1.tgz",
+      "integrity": "sha512-6u3x/iIN5fyj8pib5QTUDmIOUiwAGhaqdSTXdqCu6v9zo2BEwdCqgEJd1uXDh3DBmPRDfiZ/ge8oUPy7LerpHg==",
+      "requires": {
+        "@trufflesuite/eth-json-rpc-filters": "^4.1.2-1",
+        "@trufflesuite/eth-json-rpc-infura": "^4.0.3-0",
+        "@trufflesuite/eth-json-rpc-middleware": "^4.4.2-1",
+        "@trufflesuite/eth-sig-util": "^1.4.2",
+        "async": "^2.5.0",
+        "backoff": "^2.5.0",
+        "clone": "^2.0.0",
+        "cross-fetch": "^2.1.0",
+        "eth-block-tracker": "^4.4.2",
+        "eth-json-rpc-errors": "^2.0.2",
+        "ethereumjs-block": "^1.2.2",
+        "ethereumjs-tx": "^1.2.0",
+        "ethereumjs-util": "^5.1.5",
+        "ethereumjs-vm": "^2.3.4",
+        "json-stable-stringify": "^1.0.1",
+        "promise-to-callback": "^1.0.0",
+        "readable-stream": "^2.2.9",
+        "request": "^2.85.0",
+        "semaphore": "^1.0.3",
+        "ws": "^5.1.1",
+        "xhr": "^2.2.0",
+        "xtend": "^4.0.1"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+          "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+          "requires": {
+            "lodash": "^4.17.14"
+          }
+        },
+        "ethereum-common": {
+          "version": "0.0.18",
+          "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.0.18.tgz",
+          "integrity": "sha1-L9w1dvIykDNYl26znaeDIT/5Uj8="
+        },
+        "ethereumjs-tx": {
+          "version": "1.3.7",
+          "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-1.3.7.tgz",
+          "integrity": "sha512-wvLMxzt1RPhAQ9Yi3/HKZTn0FZYpnsmQdbKYfUUpi4j1SEIcbkd9tndVjcPrufY3V7j2IebOpC00Zp2P/Ay2kA==",
+          "requires": {
+            "ethereum-common": "^0.0.18",
+            "ethereumjs-util": "^5.0.0"
+          }
+        },
+        "ethereumjs-util": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
+          "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
+          "requires": {
+            "bn.js": "^4.11.0",
+            "create-hash": "^1.1.2",
+            "elliptic": "^6.5.2",
+            "ethereum-cryptography": "^0.1.3",
+            "ethjs-util": "^0.1.3",
+            "rlp": "^2.0.0",
+            "safe-buffer": "^5.1.1"
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        },
+        "ws": {
+          "version": "5.2.2",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
+          "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
+          "requires": {
+            "async-limiter": "~1.0.0"
+          }
+        }
+      }
+    },
     "@turist/fetch": {
       "version": "7.1.7",
       "resolved": "https://registry.npmjs.org/@turist/fetch/-/fetch-7.1.7.tgz",
@@ -6375,6 +6639,14 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/warning/-/warning-3.0.0.tgz",
       "integrity": "sha1-DSUBJorY+ZYrdA04fEZU9fjiPlI="
+    },
+    "@types/web3": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@types/web3/-/web3-1.2.2.tgz",
+      "integrity": "sha512-eFiYJKggNrOl0nsD+9cMh2MLk4zVBfXfGnVeRFbpiZzBE20eet4KLA3fXcjSuHaBn0RnQzwLAGdgzgzdet4C0A==",
+      "requires": {
+        "web3": "*"
+      }
     },
     "@types/webpack": {
       "version": "4.41.21",
@@ -7226,6 +7498,11 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/any-base/-/any-base-1.1.0.tgz",
       "integrity": "sha512-uMgjozySS8adZZYePpaWs8cxB9/kdzmpX6SgJZ+wbz1K5eYk5QMYDVJaZKhxyIHUdnnJkfR7SVgStgH7LkGUyg=="
+    },
+    "any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8="
     },
     "anymatch": {
       "version": "3.1.1",
@@ -14242,9 +14519,14 @@
         "setimmediate": "^1.0.5"
       }
     },
+    "ethereum-protocol": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ethereum-protocol/-/ethereum-protocol-1.0.1.tgz",
+      "integrity": "sha512-3KLX1mHuEsBW0dKG+c6EOJS1NBNqdCICvZW9sInmZTt5aY0oxmHVggYRE0lJu1tcnMD1K+AKHdLi6U43Awm1Vg=="
+    },
     "ethereumjs-abi": {
-      "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#1cfbb13862f90f0b391d8a699544d5fe4dfb8c7b",
-      "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
+      "version": "0.6.8",
+      "resolved": "git+https://github.com/ethereumjs/ethereumjs-abi.git#1cfbb13862f90f0b391d8a699544d5fe4dfb8c7b",
       "requires": {
         "bn.js": "^4.11.8",
         "ethereumjs-util": "^6.0.0"
@@ -14409,6 +14691,29 @@
               }
             }
           }
+        }
+      }
+    },
+    "ethereumjs-wallet": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/ethereumjs-wallet/-/ethereumjs-wallet-0.6.5.tgz",
+      "integrity": "sha512-MDwjwB9VQVnpp/Dc1XzA6J1a3wgHQ4hSvA1uWNatdpOrtCbPVuQSKSyRnjLvS0a+KKMw2pvQ9Ybqpb3+eW8oNA==",
+      "requires": {
+        "aes-js": "^3.1.1",
+        "bs58check": "^2.1.2",
+        "ethereum-cryptography": "^0.1.3",
+        "ethereumjs-util": "^6.0.0",
+        "randombytes": "^2.0.6",
+        "safe-buffer": "^5.1.2",
+        "scryptsy": "^1.2.1",
+        "utf8": "^3.0.0",
+        "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
         }
       }
     },
@@ -31379,6 +31684,14 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
       "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA=="
+    },
+    "scryptsy": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/scryptsy/-/scryptsy-1.2.1.tgz",
+      "integrity": "sha1-oyJfpLJST4AnAHYeKFW987LZIWM=",
+      "requires": {
+        "pbkdf2": "^3.0.3"
+      }
     },
     "secp256k1": {
       "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@sindresorhus/slugify": "^1.0.0",
     "@tippyjs/react": "^4.1.0",
     "@toruslabs/torus-embed": "^1.8.4",
+    "@truffle/hdwallet-provider": "^1.0.44",
     "@types/classnames": "^2.2.10",
     "@vercel/node": "^1.8.2",
     "@walletconnect/web3-provider": "^1.2.2",

--- a/src/helpers/wrapRootElement.tsx
+++ b/src/helpers/wrapRootElement.tsx
@@ -9,6 +9,7 @@ import {
   ConfigHelperNetworkId
 } from '@oceanprotocol/lib/dist/node/utils/ConfigHelper'
 import { UserPreferencesProvider } from '../providers/UserPreferences'
+import HDWalletProvider from '@truffle/hdwallet-provider'
 
 export function getOceanConfig(
   network: ConfigHelperNetworkName | ConfigHelperNetworkId
@@ -27,8 +28,21 @@ export default function wrapRootElement({
   const { metadataStoreUri, network } = appConfig
   const oceanInitialConfig = getOceanConfig(network)
 
+  let burnerWeb3provider
+
+  if (!window?.ethereum) {
+    const mnemonic =
+      'chapter method soul still duty bunker swallow tell flower obvious until claim' // 12 word
+    burnerWeb3provider = new HDWalletProvider(
+      mnemonic,
+      oceanInitialConfig.nodeUri
+    )
+    console.log(burnerWeb3provider)
+  }
+
   const initialConfig = {
     ...oceanInitialConfig,
+    ...(burnerWeb3provider && { web3provider: burnerWeb3provider }),
     // add metadataStoreUri only when defined
     ...(metadataStoreUri && { metadataStoreUri })
   }


### PR DESCRIPTION
Workaround before refactoring everything with The Graph. Initiate `Ocean` with a custom burner wallet at start of app for:

- [x] non-web3 browsers
- [ ] web3-capable but not connected to wallet
- [ ] only use for price fetching, prevent burner wallet usage for publish/consume (?)

Closes #77