### PR TITLE
network agnostic bookmarks

### DIFF
--- a/src/components/organisms/AssetContent/Bookmark.tsx
+++ b/src/components/organisms/AssetContent/Bookmark.tsx
@@ -2,10 +2,15 @@ import { useUserPreferences } from '../../../providers/UserPreferences'
 import React, { ReactElement } from 'react'
 import styles from './Bookmark.module.css'
 import { ReactComponent as BookmarkIcon } from '../../../images/bookmark.svg'
+import { useOcean } from '@oceanprotocol/react'
+import { ConfigHelperConfig } from '@oceanprotocol/lib/dist/node/utils/ConfigHelper'
 
 export default function Bookmark({ did }: { did: string }): ReactElement {
+  const { config } = useOcean()
   const { bookmarks, addBookmark, removeBookmark } = useUserPreferences()
-  const isBookmarked = bookmarks?.includes(did)
+  const isBookmarked =
+    bookmarks &&
+    bookmarks[(config as ConfigHelperConfig).network]?.includes(did)
 
   function handleBookmark() {
     isBookmarked ? removeBookmark(did) : addBookmark(did)

--- a/src/providers/UserPreferences.tsx
+++ b/src/providers/UserPreferences.tsx
@@ -8,12 +8,17 @@ import React, {
 } from 'react'
 import { Logger } from '@oceanprotocol/lib'
 import { LogLevel } from '@oceanprotocol/lib/dist/node/utils/Logger'
+import { useOcean } from '@oceanprotocol/react'
+import { getNetworkName } from '../utils/wallet'
+import { ConfigHelperConfig } from '@oceanprotocol/lib/dist/node/utils/ConfigHelper'
 
 interface UserPreferencesValue {
   debug: boolean
   currency: string
   locale: string
-  bookmarks: string[]
+  bookmarks: {
+    [network: string]: string[]
+  }
   setDebug: (value: boolean) => void
   setCurrency: (value: string) => void
   addBookmark: (did: string) => void
@@ -43,6 +48,8 @@ function UserPreferencesProvider({
 }: {
   children: ReactNode
 }): ReactElement {
+  const { config } = useOcean()
+  const networkName = (config as ConfigHelperConfig).network
   const localStorage = getLocalStorage()
 
   // Set default values from localStorage
@@ -51,7 +58,7 @@ function UserPreferencesProvider({
     localStorage?.currency || 'EUR'
   )
   const [locale, setLocale] = useState<string>()
-  const [bookmarks, setBookmarks] = useState(localStorage?.bookmarks || [])
+  const [bookmarks, setBookmarks] = useState(localStorage?.bookmarks || {})
 
   // Write values to localStorage on change
   useEffect(() => {
@@ -72,12 +79,20 @@ function UserPreferencesProvider({
   }, [])
 
   function addBookmark(didToAdd: string): void {
-    const newPinned = [didToAdd].concat(bookmarks)
+    const newPinned = {
+      ...bookmarks,
+      [networkName]: [didToAdd].concat(bookmarks[networkName])
+    }
     setBookmarks(newPinned)
   }
 
   function removeBookmark(didToAdd: string): void {
-    const newPinned = bookmarks.filter((did: string) => did !== didToAdd)
+    const newPinned = {
+      ...bookmarks,
+      [networkName]: bookmarks[networkName].filter(
+        (did: string) => did !== didToAdd
+      )
+    }
     setBookmarks(newPinned)
   }
 

--- a/src/providers/UserPreferences.tsx
+++ b/src/providers/UserPreferences.tsx
@@ -96,6 +96,13 @@ function UserPreferencesProvider({
     setBookmarks(newPinned)
   }
 
+  // Bookmarks old data structure migration
+  useEffect(() => {
+    if (!bookmarks.length) return
+    const newPinned = { mainnet: bookmarks as any }
+    setBookmarks(newPinned)
+  }, [bookmarks])
+
   return (
     <UserPreferencesContext.Provider
       value={


### PR DESCRIPTION
Refactor to make `bookmarks` network agnostic based on user's selected network. Includes old data structure migration so users with existing bookmarks will not loose their bookmarks. They are automatically migrated to `bookmarks.mainnet`.

Also fixes broken switching to Rinkeby when having used bookmarks, and being on front page.