### PR TITLE
output owner on asset details

### DIFF
--- a/src/components/organisms/AssetContent/index.tsx
+++ b/src/components/organisms/AssetContent/index.tsx
@@ -12,6 +12,7 @@ import Pricing from './Pricing'
 import { useOcean, usePricing } from '@oceanprotocol/react'
 import EtherscanLink from '../../atoms/EtherscanLink'
 import Bookmark from './Bookmark'
+import { accountTruncate } from '../../../utils/wallet'
 
 export interface AssetContentProps {
   metadata: MetadataMarket
@@ -38,7 +39,9 @@ export default function AssetContent({
 
         <div className={styles.content}>
           <aside className={styles.meta}>
-            <p className={styles.author}>{metadata?.main.author}</p>
+            <p className={styles.author} title="Author">
+              {metadata?.main.author}
+            </p>
 
             <p className={styles.datatoken}>
               <EtherscanLink
@@ -50,6 +53,16 @@ export default function AssetContent({
                 ) : (
                   <code>{ddo.dataToken}</code>
                 )}
+              </EtherscanLink>
+            </p>
+
+            <p className={styles.datatoken} title={ddo.publicKey[0].owner}>
+              Published by{' '}
+              <EtherscanLink
+                networkId={networkId}
+                path={`address/${ddo.publicKey[0].owner}`}
+              >
+                {accountTruncate(ddo.publicKey[0].owner)}
               </EtherscanLink>
             </p>
 


### PR DESCRIPTION
Tricky to call it owner in UI so opted for "Published by", although I know we have the concept of transfer ownership.

Also opted for linking address to etherscan for now, also allows us to truncate it. There is a case to be made to link it to the market search for this address, but think we do not have this search mechanism right now.

<img width="671" alt="Screen Shot 2020-10-30 at 14 43 49" src="https://user-images.githubusercontent.com/90316/97712193-69702e00-1abe-11eb-94c9-ef95e8ad79f9.png">

closes #171 