### PR TITLE
refined conversion number formatting, add more currencies

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -11,7 +11,6 @@ module.exports = {
     '0x903322C7E45A60d7c8C3EA236c5beA9Af86310c7',
   // Used for conversion display, can be whatever coingecko API supports
   // see: https://api.coingecko.com/api/v3/simple/supported_vs_currencies
-  // Needs to be synced with the `isFiat` regex in atoms/Price/Conversion.tsx
   currencies: [
     'EUR',
     'USD',

--- a/app.config.js
+++ b/app.config.js
@@ -11,7 +11,7 @@ module.exports = {
     '0x903322C7E45A60d7c8C3EA236c5beA9Af86310c7',
   // Used for conversion display, can be whatever coingecko API supports
   // see: https://api.coingecko.com/api/v3/simple/supported_vs_currencies
-  currencies: ['EUR', 'USD', 'ETH', 'BTC'],
+  currencies: ['EUR', 'USD', 'CAD', 'GBP', 'SGD', 'CNY', 'ETH', 'BTC', 'LINK'],
 
   // Config for https://github.com/donavon/use-dark-mode
   darkModeConfig: {

--- a/app.config.js
+++ b/app.config.js
@@ -11,7 +11,22 @@ module.exports = {
     '0x903322C7E45A60d7c8C3EA236c5beA9Af86310c7',
   // Used for conversion display, can be whatever coingecko API supports
   // see: https://api.coingecko.com/api/v3/simple/supported_vs_currencies
-  currencies: ['EUR', 'USD', 'CAD', 'GBP', 'SGD', 'CNY', 'ETH', 'BTC', 'LINK'],
+  // Needs to be synced with the `isFiat` regex in atoms/Price/Conversion.tsx
+  currencies: [
+    'EUR',
+    'USD',
+    'CAD',
+    'GBP',
+    'SGD',
+    'HKD',
+    'CNY',
+    'JPY',
+    'INR',
+    'RUB',
+    'ETH',
+    'BTC',
+    'LINK'
+  ],
 
   // Config for https://github.com/donavon/use-dark-mode
   darkModeConfig: {

--- a/src/components/atoms/Price/Conversion.module.css
+++ b/src/components/atoms/Price/Conversion.module.css
@@ -5,3 +5,9 @@
   color: var(--color-secondary);
   font-weight: var(--font-weight-base);
 }
+
+/* fiat currency symbol */
+.conversion strong span {
+  font-weight: var(--font-weight-base);
+  color: var(--color-secondary);
+}

--- a/src/components/atoms/Price/Conversion.tsx
+++ b/src/components/atoms/Price/Conversion.tsx
@@ -18,6 +18,7 @@ export default function Conversion({
   const { currency, locale } = useUserPreferences()
 
   const [priceConverted, setPriceConverted] = useState('0.00')
+  const isFiat = currency === 'EUR' || currency === 'USD'
 
   const styleClasses = cx({
     conversion: true,
@@ -30,17 +31,15 @@ export default function Conversion({
       return
     }
 
-    const fiatValue = (prices as any)[currency.toLowerCase()]
-    const converted = fiatValue * Number(price)
-    const convertedFormatted = formatCurrency(
-      converted,
-      currency,
-      locale,
-      true,
-      { decimalPlaces: 2 }
-    )
+    const conversionValue = (prices as any)[currency.toLowerCase()]
+    const converted = conversionValue * Number(price)
+    const convertedFormatted = formatCurrency(converted, '', locale, false, {
+      decimalPlaces: 2,
+      // only this gives us 2 decimals for fiat
+      ...(isFiat && { significantFigures: 2 })
+    })
     setPriceConverted(convertedFormatted)
-  }, [price, prices, currency, locale])
+  }, [price, prices, currency, locale, isFiat])
 
   return (
     <span

--- a/src/components/atoms/Price/Conversion.tsx
+++ b/src/components/atoms/Price/Conversion.tsx
@@ -18,7 +18,7 @@ export default function Conversion({
   const { currency, locale } = useUserPreferences()
 
   const [priceConverted, setPriceConverted] = useState('0.00')
-  const isFiat = currency === 'EUR' || currency === 'USD'
+  const isFiat = /(EUR|USD|CAD|SGD|CNY|GBP)/g.test(currency)
 
   const styleClasses = cx({
     conversion: true,
@@ -33,11 +33,15 @@ export default function Conversion({
 
     const conversionValue = (prices as any)[currency.toLowerCase()]
     const converted = conversionValue * Number(price)
-    const convertedFormatted = formatCurrency(converted, '', locale, false, {
-      decimalPlaces: 2,
-      // only this gives us 2 decimals for fiat
-      ...(isFiat && { significantFigures: 2 })
-    })
+    const convertedFormatted = formatCurrency(
+      converted,
+      // No passing of `currency` for non-fiat so symbol conversion
+      // doesn't get triggered.
+      isFiat ? currency : '',
+      locale,
+      false,
+      { decimalPlaces: 2 }
+    )
     setPriceConverted(convertedFormatted)
   }, [price, prices, currency, locale, isFiat])
 
@@ -46,7 +50,7 @@ export default function Conversion({
       className={styleClasses}
       title="Approximation based on current OCEAN spot price on Coingecko"
     >
-      ≈ <strong>{priceConverted}</strong> {currency}
+      ≈ <strong>{priceConverted}</strong> {isFiat ? '' : currency}
     </span>
   )
 }

--- a/src/components/atoms/Price/Conversion.tsx
+++ b/src/components/atoms/Price/Conversion.tsx
@@ -18,7 +18,8 @@ export default function Conversion({
   const { currency, locale } = useUserPreferences()
 
   const [priceConverted, setPriceConverted] = useState('0.00')
-  const isFiat = /(EUR|USD|CAD|SGD|CNY|GBP)/g.test(currency)
+  // detect fiat, only have those kick in full @coingecko/cryptoformat formatting
+  const isFiat = /(EUR|USD|CAD|SGD|HKD|CNY|JPY|GBP|INR|RUB)/g.test(currency)
 
   const styleClasses = cx({
     conversion: true,

--- a/src/components/atoms/Price/Conversion.tsx
+++ b/src/components/atoms/Price/Conversion.tsx
@@ -42,7 +42,13 @@ export default function Conversion({
       false,
       { decimalPlaces: 2 }
     )
-    setPriceConverted(convertedFormatted)
+    // It's a hack! Wrap everything in the string which is not a number or `.` or `,`
+    // with a span for consistent visual symbol formatting.
+    const convertedFormattedHTMLstring = convertedFormatted.replace(
+      /([^.,0-9]+)/g,
+      (match) => `<span>${match}</span>`
+    )
+    setPriceConverted(convertedFormattedHTMLstring)
   }, [price, prices, currency, locale, isFiat])
 
   return (
@@ -50,7 +56,8 @@ export default function Conversion({
       className={styleClasses}
       title="Approximation based on current OCEAN spot price on Coingecko"
     >
-      ≈ <strong>{priceConverted}</strong> {isFiat ? '' : currency}
+      ≈ <strong dangerouslySetInnerHTML={{ __html: priceConverted }} />{' '}
+      {!isFiat && currency}
     </span>
   )
 }

--- a/src/components/atoms/Price/Conversion.tsx
+++ b/src/components/atoms/Price/Conversion.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState, ReactElement } from 'react'
 import styles from './Conversion.module.css'
 import classNames from 'classnames/bind'
-import { formatCurrency } from '@coingecko/cryptoformat'
+import { formatCurrency, isCrypto } from '@coingecko/cryptoformat'
 import { useUserPreferences } from '../../../providers/UserPreferences'
 import { usePrices } from '../../../providers/Prices'
 
@@ -19,7 +19,9 @@ export default function Conversion({
 
   const [priceConverted, setPriceConverted] = useState('0.00')
   // detect fiat, only have those kick in full @coingecko/cryptoformat formatting
-  const isFiat = /(EUR|USD|CAD|SGD|HKD|CNY|JPY|GBP|INR|RUB)/g.test(currency)
+  const isFiat = !isCrypto(currency)
+  // isCrypto() only checks for BTC & ETH & unknown but seems sufficient for now
+  // const isFiat = /(EUR|USD|CAD|SGD|HKD|CNY|JPY|GBP|INR|RUB)/g.test(currency)
 
   const styleClasses = cx({
     conversion: true,

--- a/src/components/atoms/Price/PriceUnit.module.css
+++ b/src/components/atoms/Price/PriceUnit.module.css
@@ -10,7 +10,7 @@
   white-space: nowrap;
 }
 
-.price span:first-child {
+.symbol {
   font-weight: var(--font-weight-base);
   color: var(--color-secondary);
   font-size: var(--font-size-base);
@@ -21,7 +21,7 @@
   font-size: var(--font-size-base);
 }
 
-.price.small span:first-child {
+.price.small .symbol {
   font-size: var(--font-size-small);
 }
 

--- a/src/components/atoms/Price/PriceUnit.tsx
+++ b/src/components/atoms/Price/PriceUnit.tsx
@@ -42,7 +42,7 @@ export default function PriceUnit({
               // See https://github.com/oceanprotocol/market/issues/70
               significantFigures: 4
             })}{' '}
-        <span>{symbol || 'OCEAN'}</span>
+        <span className={styles.symbol}>{symbol || 'OCEAN'}</span>
         {type && type === 'pool' && (
           <Badge label="pool" className={styles.badge} />
         )}

--- a/src/components/molecules/Wallet/Details.module.css
+++ b/src/components/molecules/Wallet/Details.module.css
@@ -14,7 +14,7 @@
   white-space: nowrap;
 }
 
-.balance span {
+.symbol {
   width: 20%;
   text-align: right;
   font-weight: var(--font-weight-base);

--- a/src/components/molecules/Wallet/Details.tsx
+++ b/src/components/molecules/Wallet/Details.tsx
@@ -17,7 +17,7 @@ export default function Details(): ReactElement {
       <ul>
         {Object.entries(balance).map(([key, value]) => (
           <li className={styles.balance} key={key}>
-            <span>{key.toUpperCase()}</span>{' '}
+            <span className={styles.symbol}>{key.toUpperCase()}</span>{' '}
             {formatCurrency(Number(value), '', locale, false, {
               significantFigures: 4
             })}

--- a/src/components/pages/History/PoolShares.tsx
+++ b/src/components/pages/History/PoolShares.tsx
@@ -41,13 +41,15 @@ const columns = [
     name: 'Your Pool Shares',
     selector: function getAssetRow(row: Asset) {
       return <PriceUnit price={row.shares} symbol="pool shares" small />
-    }
+    },
+    right: true
   },
   {
     name: 'Total Pool Liquidity',
     selector: function getAssetRow(row: Asset) {
       return <TotalLiquidity ddo={row.ddo} />
-    }
+    },
+    right: true
   }
 ]
 


### PR DESCRIPTION
Hack `@coingecko/cryptoformat` into what we want, so numbers are formatted consistently with their thousands separator (the format based on user's locale), no matter if fiat or crypto. For fiat conversion, switch to displaying with locale symbol.  Also add more conversion currencies to choose from: CAD, GBP, SGD, HKD, CNY, JPY, INR, RUB, LINK.

Before:
<img width="433" alt="Screen Shot 2020-10-31 at 13 36 08" src="https://user-images.githubusercontent.com/90316/97779631-92a4c300-1b7f-11eb-910a-3c19755f8907.png">

After (for en-US locale):
<img width="461" alt="Screen Shot 2020-10-31 at 15 23 42" src="https://user-images.githubusercontent.com/90316/97781634-1618e100-1b8d-11eb-9f38-67e5c2185544.png">

<img width="452" alt="Screen Shot 2020-10-31 at 15 08 20" src="https://user-images.githubusercontent.com/90316/97781347-f2549b80-1b8a-11eb-95e2-3ecc5f4a7c0f.png">

<img width="449" alt="Screen Shot 2020-10-31 at 15 08 56" src="https://user-images.githubusercontent.com/90316/97781363-03051180-1b8b-11eb-9283-d3d3fb45eb2b.png">

Conversion number uses 2 decimals when it's a fiat currency, otherwise will use 3-4 decimal places and continue to use existing symbol format:
<img width="456" alt="Screen Shot 2020-10-31 at 13 48 08" src="https://user-images.githubusercontent.com/90316/97779652-b831cc80-1b7f-11eb-92e2-f3ba0f36d1ec.png">
