### PR TITLE
lower min amount for adding token

### DIFF
--- a/src/components/organisms/AssetActions/Pool/Add/index.tsx
+++ b/src/components/organisms/AssetActions/Pool/Add/index.tsx
@@ -79,7 +79,7 @@ export default function Add({
   // https://github.com/jquense/yup#number
   const validationSchema = Yup.object().shape<FormAddLiquidity>({
     amount: Yup.number()
-      .min(0.01, 'Must be more or equal to 0.01')
+      .min(0.0001, 'Must be more or equal to 0.0001')
       .max(
         Number(amountMax),
         `Maximum you can add is ${Number(amountMax).toFixed(2)} ${coin}`


### PR DESCRIPTION
Some assets have rather expensive datatoken, making fractions worth a lot. So lower the live-validation amount which can be added back to pool.

Still needs to be verified:
- low OCEAN or DT amounts do not pose a problem along the stack, so this change does not result in failing transactions
- we might need to decide and implement different min amounts for OCEAN and DT