### PR TITLE
re-fetch pool numbers every 10 sec.

### DIFF
--- a/src/components/organisms/AssetActions/Pool/Remove.tsx
+++ b/src/components/organisms/AssetActions/Pool/Remove.tsx
@@ -49,12 +49,14 @@ export default function Remove({
   refreshInfo,
   poolAddress,
   poolTokens,
+  totalPoolTokens,
   dtSymbol
 }: {
   setShowRemove: (show: boolean) => void
   refreshInfo: () => void
   poolAddress: string
   poolTokens: string
+  totalPoolTokens: string
   dtSymbol: string
 }): ReactElement {
   const data = useStaticQuery(contentQuery)
@@ -157,7 +159,14 @@ export default function Remove({
       }
     }, 300)
     getValues()
-  }, [amountPercent, isAdvanced, ocean, poolTokens, poolAddress])
+  }, [
+    amountPercent,
+    isAdvanced,
+    ocean,
+    poolTokens,
+    poolAddress,
+    totalPoolTokens
+  ])
 
   return (
     <div className={styles.remove}>

--- a/src/components/organisms/AssetActions/Pool/TokenList.module.css
+++ b/src/components/organisms/AssetActions/Pool/TokenList.module.css
@@ -4,6 +4,7 @@
   padding: calc(var(--spacer) / 1.5) calc(var(--spacer) / 1.5)
     calc(var(--spacer) / 2) calc(var(--spacer) / 1.5);
   border-top: 1px solid var(--border-color);
+  position: relative;
 }
 
 @media (min-width: 40rem) {

--- a/src/components/organisms/AssetActions/Pool/index.module.css
+++ b/src/components/organisms/AssetActions/Pool/index.module.css
@@ -6,6 +6,7 @@
   padding-left: calc(var(--spacer) / 1.5);
   padding-right: calc(var(--spacer) / 1.5);
   text-align: center;
+  position: relative;
 }
 
 .dataTokenLinks {
@@ -18,4 +19,39 @@
 .dataTokenLinks a {
   margin-left: calc(var(--spacer) / 3);
   margin-right: calc(var(--spacer) / 3);
+}
+
+.update {
+  font-size: var(--font-size-mini);
+  color: var(--color-secondary);
+  text-align: center;
+  border-top: 1px solid var(--border-color);
+  margin-left: -2rem;
+  margin-right: -2rem;
+  padding-top: calc(var(--spacer) / 4);
+}
+
+.update:before {
+  content: '';
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  display: inline-block;
+  border: 1px solid var(--brand-alert-green);
+  margin-right: 0.2rem;
+  margin-top: -0.1rem;
+  vertical-align: middle;
+  animation: pulse 2s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0% {
+    background: transparent;
+  }
+  50% {
+    background: var(--brand-alert-green);
+  }
+  100% {
+    background: transparent;
+  }
 }

--- a/src/components/organisms/AssetActions/Pool/index.tsx
+++ b/src/components/organisms/AssetActions/Pool/index.tsx
@@ -170,11 +170,17 @@ export default function Pool({ ddo }: { ddo: DDO }): ReactElement {
       }
     }
     init()
+
+    // Re-fetch price every 10 sec., triggering re-calculation of everything
+    const interval = setInterval(refreshPrice, 10000)
+    return () => {
+      clearInterval(interval)
+    }
   }, [ocean, accountId, price, ddo.dataToken, refreshPool, ddo.publicKey])
 
   const refreshInfo = async () => {
     setRefreshPool(!refreshPool)
-    await refreshPrice()
+    refreshPrice()
   }
 
   return (

--- a/src/components/organisms/AssetActions/Pool/index.tsx
+++ b/src/components/organisms/AssetActions/Pool/index.tsx
@@ -202,6 +202,7 @@ export default function Pool({ ddo }: { ddo: DDO }): ReactElement {
           refreshInfo={refreshInfo}
           poolAddress={price.address}
           poolTokens={poolTokens}
+          totalPoolTokens={totalPoolTokens}
           dtSymbol={dtSymbol}
         />
       ) : (

--- a/src/components/organisms/AssetActions/Pool/index.tsx
+++ b/src/components/organisms/AssetActions/Pool/index.tsx
@@ -266,9 +266,11 @@ export default function Pool({ ddo }: { ddo: DDO }): ReactElement {
             <Token symbol="% swap fee" balance={swapFee} noIcon />
           </TokenList>
 
-          <div className={styles.update}>
-            Fetching every {refreshInterval / 1000} sec.
-          </div>
+          {ocean && (
+            <div className={styles.update}>
+              Fetching every {refreshInterval / 1000} sec.
+            </div>
+          )}
 
           <div className={stylesActions.actions}>
             <Button

--- a/src/components/organisms/AssetActions/Pool/index.tsx
+++ b/src/components/organisms/AssetActions/Pool/index.tsx
@@ -37,6 +37,8 @@ const contentQuery = graphql`
   }
 `
 
+const refreshInterval = 10000 // 10 sec.
+
 export default function Pool({ ddo }: { ddo: DDO }): ReactElement {
   const data = useStaticQuery(contentQuery)
   const content = data.content.edges[0].node.childContentJson.pool
@@ -171,12 +173,10 @@ export default function Pool({ ddo }: { ddo: DDO }): ReactElement {
     }
     init()
 
-    // Re-fetch price every 10 sec., triggering re-calculation of everything
-    const interval = setInterval(refreshPrice, 10000)
-    return () => {
-      clearInterval(interval)
-    }
-  }, [ocean, accountId, price, ddo.dataToken, refreshPool, ddo.publicKey])
+    // Re-fetch price periodically, triggering re-calculation of everything
+    const interval = setInterval(() => refreshPrice(), refreshInterval)
+    return () => clearInterval(interval)
+  }, [ocean, accountId, price, ddo, refreshPool])
 
   const refreshInfo = async () => {
     setRefreshPool(!refreshPool)
@@ -264,6 +264,10 @@ export default function Pool({ ddo }: { ddo: DDO }): ReactElement {
           >
             <Token symbol="% swap fee" balance={swapFee} noIcon />
           </TokenList>
+
+          <div className={styles.update}>
+            Fetching every {refreshInterval / 1000} sec.
+          </div>
 
           <div className={stylesActions.actions}>
             <Button

--- a/src/components/organisms/AssetActions/Pool/index.tsx
+++ b/src/components/organisms/AssetActions/Pool/index.tsx
@@ -180,7 +180,7 @@ export default function Pool({ ddo }: { ddo: DDO }): ReactElement {
 
   const refreshInfo = async () => {
     setRefreshPool(!refreshPool)
-    refreshPrice()
+    await refreshPrice()
   }
 
   return (

--- a/src/components/organisms/AssetActions/index.tsx
+++ b/src/components/organisms/AssetActions/index.tsx
@@ -37,8 +37,7 @@ export default function AssetActions({ ddo }: { ddo: DDO }): ReactElement {
 
   // Check user balance against price
   useEffect(() => {
-    if (!price || !price.value || !balance || !balance.ocean || !dtBalance)
-      return
+    if (!price?.value || !accountId || !balance?.ocean || !dtBalance) return
 
     setIsBalanceSufficient(
       compareAsBN(balance.ocean, `${price.value}`) || Number(dtBalance) >= 1
@@ -47,7 +46,7 @@ export default function AssetActions({ ddo }: { ddo: DDO }): ReactElement {
     return () => {
       setIsBalanceSufficient(false)
     }
-  }, [balance, price, dtBalance])
+  }, [balance, accountId, price, dtBalance])
 
   const UseContent = isCompute ? (
     <Compute


### PR DESCRIPTION
Re-fetch price and recalculate all numbers every 10 sec. so users do not have to reload to get new values. Seems ok performance-wise when doing this only on the asset details page within the pool widget.

<img width="451" alt="Screen Shot 2020-11-02 at 02 05 44" src="https://user-images.githubusercontent.com/90316/97820760-ef9f9680-1caf-11eb-811d-8fb17b256793.png">