### PR TITLE
User pool transactions on asset details

### DIFF
--- a/src/components/atoms/SuccessConfetti.tsx
+++ b/src/components/atoms/SuccessConfetti.tsx
@@ -25,10 +25,12 @@ const confettiConfig = {
 
 export default function SuccessConfetti({
   success,
-  action
+  action,
+  className
 }: {
   success: string
   action?: ReactNode
+  className?: string
 }): ReactElement {
   // Have some confetti upon success
   useEffect(() => {
@@ -41,11 +43,11 @@ export default function SuccessConfetti({
   }, [success])
 
   return (
-    <>
+    <div className={className || null}>
       <Alert text={success} state="success" />
       <span className={styles.action} data-confetti>
         {action}
       </span>
-    </>
+    </div>
   )
 }

--- a/src/components/atoms/Table.module.css
+++ b/src/components/atoms/Table.module.css
@@ -6,6 +6,7 @@
 .table [role='row'] {
   color: var(--font-color-text);
   font-size: var(--font-size-small);
+  min-width: 0;
 }
 
 .table [class~='rdt_TableCol'] {
@@ -26,6 +27,7 @@
   font-size: var(--font-size-small);
   color: var(--color-secondary);
   background: none;
+  min-height: 0;
 }
 
 .table + div [class*='rdt_Pagination'] svg {

--- a/src/components/atoms/Table.tsx
+++ b/src/components/atoms/Table.tsx
@@ -17,6 +17,8 @@ export default function Table({
   columns,
   isLoading,
   emptyMessage,
+  pagination,
+  paginationPerPage,
   ...props
 }: TableProps): ReactElement {
   return (
@@ -25,8 +27,8 @@ export default function Table({
       data={data}
       className={styles.table}
       noHeader
-      pagination={data?.length >= 9}
-      paginationPerPage={10}
+      pagination={pagination || data?.length >= 9}
+      paginationPerPage={paginationPerPage || 10}
       paginationComponentOptions={{ noRowsPerPage: true }}
       noDataComponent={<Empty message={emptyMessage} />}
       progressPending={isLoading}

--- a/src/components/atoms/Time.tsx
+++ b/src/components/atoms/Time.tsx
@@ -4,11 +4,13 @@ import { format, formatDistance } from 'date-fns'
 export default function Time({
   date,
   relative,
-  isUnix
+  isUnix,
+  className
 }: {
   date: string
   relative?: boolean
   isUnix?: boolean
+  className?: string
 }): ReactElement {
   const dateNew = isUnix ? new Date(Number(date) * 1000) : new Date(date)
   const dateIso = dateNew.toISOString()
@@ -19,6 +21,7 @@ export default function Time({
     <time
       title={relative ? format(dateNew, 'MMMM d, yyyy') : undefined}
       dateTime={dateIso}
+      className={className || undefined}
     >
       {relative
         ? formatDistance(dateNew, Date.now(), { addSuffix: true })

--- a/src/components/molecules/PoolTransactions.module.css
+++ b/src/components/molecules/PoolTransactions.module.css
@@ -1,0 +1,3 @@
+.time {
+  color: var(--color-secondary);
+}

--- a/src/components/molecules/PoolTransactions.tsx
+++ b/src/components/molecules/PoolTransactions.tsx
@@ -47,37 +47,8 @@ function Title({ row }: { row: PoolTransaction }) {
   )
 }
 
-export default function PoolTransactions({
-  poolAddress,
-  minimal
-}: {
-  poolAddress?: string
-  minimal?: boolean
-}): ReactElement {
-  const { ocean, accountId } = useOcean()
-  const [logs, setLogs] = useState<PoolTransaction[]>()
-  const [isLoading, setIsLoading] = useState(false)
-
-  useEffect(() => {
-    async function getLogs() {
-      if (!ocean || !accountId) return
-      setIsLoading(true)
-      const logs = poolAddress
-        ? await ocean.pool.getPoolLogs(poolAddress, 0, accountId)
-        : await ocean.pool.getAllPoolLogs(accountId)
-      // sort logs by date, newest first
-      const logsSorted = logs.sort((a, b) => {
-        if (a.timestamp > b.timestamp) return -1
-        if (a.timestamp < b.timestamp) return 1
-        return 0
-      })
-      setLogs(logsSorted)
-      setIsLoading(false)
-    }
-    getLogs()
-  }, [ocean, accountId, poolAddress])
-
-  const columns = [
+function getColumns(minimal?: boolean) {
+  return [
     {
       name: 'Title',
       selector: function getTitleRow(row: PoolTransaction) {
@@ -108,10 +79,42 @@ export default function PoolTransactions({
       }
     }
   ]
+}
+
+export default function PoolTransactions({
+  poolAddress,
+  minimal
+}: {
+  poolAddress?: string
+  minimal?: boolean
+}): ReactElement {
+  const { ocean, accountId } = useOcean()
+  const [logs, setLogs] = useState<PoolTransaction[]>()
+  const [isLoading, setIsLoading] = useState(false)
+
+  useEffect(() => {
+    async function getLogs() {
+      if (!ocean || !accountId) return
+
+      setIsLoading(true)
+      const logs = poolAddress
+        ? await ocean.pool.getPoolLogs(poolAddress, 0, accountId)
+        : await ocean.pool.getAllPoolLogs(accountId)
+      // sort logs by date, newest first
+      const logsSorted = logs.sort((a, b) => {
+        if (a.timestamp > b.timestamp) return -1
+        if (a.timestamp < b.timestamp) return 1
+        return 0
+      })
+      setLogs(logsSorted)
+      setIsLoading(false)
+    }
+    getLogs()
+  }, [ocean, accountId, poolAddress])
 
   return (
     <Table
-      columns={columns}
+      columns={getColumns(minimal)}
       data={logs}
       isLoading={isLoading}
       noTableHead={minimal}

--- a/src/components/molecules/PoolTransactions.tsx
+++ b/src/components/molecules/PoolTransactions.tsx
@@ -4,15 +4,29 @@ import React, { ReactElement, useEffect, useState } from 'react'
 import EtherscanLink from '../atoms/EtherscanLink'
 import Time from '../atoms/Time'
 import Table from '../atoms/Table'
-import AssetTitle from '../molecules/AssetTitle'
+import AssetTitle from './AssetTitle'
+import styles from './PoolTransactions.module.css'
+import { formatCurrency } from '@coingecko/cryptoformat'
+import { useUserPreferences } from '../../providers/UserPreferences'
+
+function formatNumber(number: number, locale: string) {
+  return formatCurrency(number, '', locale, false, {
+    significantFigures: 4
+  })
+}
 
 function Title({ row }: { row: PoolTransaction }) {
   const { ocean, networkId } = useOcean()
   const [dtSymbol, setDtSymbol] = useState<string>()
+  const { locale } = useUserPreferences()
 
   const title = row.tokenAmountIn
-    ? `Add ${row.tokenAmountIn} ${dtSymbol || 'OCEAN'}`
-    : `Remove ${row.tokenAmountOut} ${dtSymbol || 'OCEAN'}`
+    ? `Add ${formatNumber(Number(row.tokenAmountIn), locale)} ${
+        dtSymbol || 'OCEAN'
+      }`
+    : `Remove ${formatNumber(Number(row.tokenAmountOut), locale)} ${
+        dtSymbol || 'OCEAN'
+      }`
 
   useEffect(() => {
     if (!ocean) return
@@ -68,7 +82,9 @@ export default function PoolTransactions({
       name: 'Title',
       selector: function getTitleRow(row: PoolTransaction) {
         return <Title row={row} />
-      }
+      },
+      minWidth: '14rem',
+      grow: 1
     },
     {
       name: 'Data Set',
@@ -81,7 +97,14 @@ export default function PoolTransactions({
     {
       name: 'Time',
       selector: function getTimeRow(row: PoolTransaction) {
-        return <Time date={row.timestamp.toString()} relative isUnix />
+        return (
+          <Time
+            className={styles.time}
+            date={row.timestamp.toString()}
+            relative
+            isUnix
+          />
+        )
       }
     }
   ]
@@ -95,6 +118,7 @@ export default function PoolTransactions({
       dense={minimal}
       pagination={minimal ? logs?.length >= 4 : logs?.length >= 9}
       paginationPerPage={minimal ? 5 : 10}
+      emptyMessage="Your pool transactions will show up here"
     />
   )
 }

--- a/src/components/organisms/AssetActions/Pool/Actions.module.css
+++ b/src/components/organisms/AssetActions/Pool/Actions.module.css
@@ -11,7 +11,7 @@
   justify-content: center;
 }
 
-.actions + div {
+.success {
   margin-top: calc(var(--spacer) / 2);
   margin-bottom: calc(var(--spacer) / 2);
 }

--- a/src/components/organisms/AssetActions/Pool/Actions.tsx
+++ b/src/components/organisms/AssetActions/Pool/Actions.tsx
@@ -41,6 +41,7 @@ export default function Actions({
       </div>
       {txId && (
         <SuccessConfetti
+          className={styles.success}
           success={successMessage}
           action={
             <EtherscanLink networkId={networkId} path={`/tx/${txId}`}>

--- a/src/components/organisms/AssetActions/Pool/TokenList.module.css
+++ b/src/components/organisms/AssetActions/Pool/TokenList.module.css
@@ -33,9 +33,7 @@
 }
 
 .title {
-  font-size: var(--font-size-base);
-  margin-bottom: calc(var(--spacer) / 3);
-  color: var(--color-secondary);
+  composes: title from './index.module.css';
 }
 
 .totalLiquidity {

--- a/src/components/organisms/AssetActions/Pool/Transactions.module.css
+++ b/src/components/organisms/AssetActions/Pool/Transactions.module.css
@@ -1,0 +1,45 @@
+.transactions {
+  composes: container from './index.module.css';
+  border-top: 1px solid var(--border-color);
+  margin-top: calc(var(--spacer) / 1.5);
+  padding: calc(var(--spacer) / 1.5);
+  background: var(--background-highlight);
+  margin-bottom: -2rem;
+}
+
+.transactions [class*='rdt_Pagination'] {
+  margin-bottom: -1rem;
+}
+
+.title {
+  composes: title from './index.module.css';
+  margin-bottom: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  cursor: pointer;
+}
+
+.title:hover .toggle {
+  color: var(--color-primary);
+}
+
+.title + div {
+  margin-top: calc(var(--spacer) / 3);
+}
+
+.toggle {
+  color: var(--color-secondary);
+}
+
+.toggle svg {
+  display: inline-block;
+  width: var(--font-size-mini);
+  height: var(--font-size-mini);
+  fill: currentColor;
+  transition: 0.2s ease-out;
+}
+
+.open .toggle svg {
+  transform: rotate(180deg);
+}

--- a/src/components/organisms/AssetActions/Pool/Transactions.tsx
+++ b/src/components/organisms/AssetActions/Pool/Transactions.tsx
@@ -1,0 +1,37 @@
+import React, { ReactElement, useState } from 'react'
+import Button from '../../../atoms/Button'
+import PoolTransactions from '../../../molecules/PoolTransactions'
+import styles from './Transactions.module.css'
+import { ReactComponent as Caret } from '../../../../images/caret.svg'
+
+export default function Transactions({
+  poolAddress
+}: {
+  poolAddress: string
+}): ReactElement {
+  const [open, setOpen] = useState(false)
+
+  function handleClick() {
+    setOpen(!open)
+  }
+
+  return (
+    <div
+      className={`${styles.transactions} ${open === true ? styles.open : ''}`}
+    >
+      {/* TODO: onClick on h3 is nasty but we're in a hurry */}
+      <h3 className={styles.title} onClick={handleClick}>
+        Your Pool Transactions{' '}
+        <Button
+          style="text"
+          size="small"
+          onClick={handleClick}
+          className={styles.toggle}
+        >
+          {open ? 'Hide' : 'Show'} <Caret />
+        </Button>
+      </h3>
+      {open === true && <PoolTransactions poolAddress={poolAddress} minimal />}
+    </div>
+  )
+}

--- a/src/components/organisms/AssetActions/Pool/index.module.css
+++ b/src/components/organisms/AssetActions/Pool/index.module.css
@@ -1,10 +1,14 @@
-.dataToken {
-  padding-bottom: calc(var(--spacer) / 1.5);
-  font-size: var(--font-size-large);
+.container {
   margin-left: -2rem;
   margin-right: -2rem;
   padding-left: calc(var(--spacer) / 1.5);
   padding-right: calc(var(--spacer) / 1.5);
+}
+
+.dataToken {
+  composes: container;
+  padding-bottom: calc(var(--spacer) / 1.5);
+  font-size: var(--font-size-large);
   text-align: center;
   position: relative;
 }
@@ -21,13 +25,18 @@
   margin-right: calc(var(--spacer) / 3);
 }
 
+.title {
+  font-size: var(--font-size-base);
+  margin-bottom: calc(var(--spacer) / 3);
+  color: var(--color-secondary);
+}
+
 .update {
+  composes: container;
   font-size: var(--font-size-mini);
   color: var(--color-secondary);
   text-align: center;
   border-top: 1px solid var(--border-color);
-  margin-left: -2rem;
-  margin-right: -2rem;
   padding-top: calc(var(--spacer) / 4);
 }
 
@@ -42,6 +51,15 @@
   margin-top: -0.1rem;
   vertical-align: middle;
   animation: pulse 2s ease-in-out infinite;
+}
+
+.transactions {
+  composes: container;
+  border-top: 1px solid var(--border-color);
+  margin-top: calc(var(--spacer) / 1.5);
+  padding: calc(var(--spacer) / 1.5);
+  background: var(--background-highlight);
+  margin-bottom: -2rem;
 }
 
 @keyframes pulse {

--- a/src/components/organisms/AssetActions/Pool/index.module.css
+++ b/src/components/organisms/AssetActions/Pool/index.module.css
@@ -62,6 +62,10 @@
   margin-bottom: -2rem;
 }
 
+.transactions [class*='rdt_Pagination'] {
+  margin-bottom: -1rem;
+}
+
 @keyframes pulse {
   0% {
     background: transparent;

--- a/src/components/organisms/AssetActions/Pool/index.module.css
+++ b/src/components/organisms/AssetActions/Pool/index.module.css
@@ -53,19 +53,6 @@
   animation: pulse 2s ease-in-out infinite;
 }
 
-.transactions {
-  composes: container;
-  border-top: 1px solid var(--border-color);
-  margin-top: calc(var(--spacer) / 1.5);
-  padding: calc(var(--spacer) / 1.5);
-  background: var(--background-highlight);
-  margin-bottom: -2rem;
-}
-
-.transactions [class*='rdt_Pagination'] {
-  margin-bottom: -1rem;
-}
-
 @keyframes pulse {
   0% {
     background: transparent;

--- a/src/components/organisms/AssetActions/Pool/index.tsx
+++ b/src/components/organisms/AssetActions/Pool/index.tsx
@@ -290,7 +290,10 @@ export default function Pool({ ddo }: { ddo: DDO }): ReactElement {
           </div>
 
           {hasAddedLiquidity && (
-            <PoolTransactions poolAddress={price?.address} minimal />
+            <div className={styles.transactions}>
+              <h3 className={styles.title}>Your Transactions</h3>
+              <PoolTransactions poolAddress={price?.address} minimal />
+            </div>
           )}
         </>
       )}

--- a/src/components/organisms/AssetActions/Pool/index.tsx
+++ b/src/components/organisms/AssetActions/Pool/index.tsx
@@ -13,6 +13,7 @@ import Token from './Token'
 import TokenList from './TokenList'
 import { graphql, useStaticQuery } from 'gatsby'
 import PoolTransactions from '../../../molecules/PoolTransactions'
+import Transactions from './Transactions'
 
 export interface Balance {
   ocean: number
@@ -283,12 +284,7 @@ export default function Pool({ ddo }: { ddo: DDO }): ReactElement {
             )}
           </div>
 
-          {accountId && (
-            <div className={styles.transactions}>
-              <h3 className={styles.title}>Your Pool Transactions</h3>
-              <PoolTransactions poolAddress={price?.address} minimal />
-            </div>
-          )}
+          {accountId && <Transactions poolAddress={price?.address} />}
         </>
       )}
     </>

--- a/src/components/organisms/AssetActions/Pool/index.tsx
+++ b/src/components/organisms/AssetActions/Pool/index.tsx
@@ -12,6 +12,7 @@ import EtherscanLink from '../../../atoms/EtherscanLink'
 import Token from './Token'
 import TokenList from './TokenList'
 import { graphql, useStaticQuery } from 'gatsby'
+import PoolTransactions from '../../PoolTransactions'
 
 export interface Balance {
   ocean: number
@@ -287,6 +288,10 @@ export default function Pool({ ddo }: { ddo: DDO }): ReactElement {
               </Button>
             )}
           </div>
+
+          {hasAddedLiquidity && (
+            <PoolTransactions poolAddress={price?.address} minimal />
+          )}
         </>
       )}
     </>

--- a/src/components/organisms/AssetActions/Pool/index.tsx
+++ b/src/components/organisms/AssetActions/Pool/index.tsx
@@ -12,7 +12,7 @@ import EtherscanLink from '../../../atoms/EtherscanLink'
 import Token from './Token'
 import TokenList from './TokenList'
 import { graphql, useStaticQuery } from 'gatsby'
-import PoolTransactions from '../../PoolTransactions'
+import PoolTransactions from '../../../molecules/PoolTransactions'
 
 export interface Balance {
   ocean: number
@@ -283,12 +283,10 @@ export default function Pool({ ddo }: { ddo: DDO }): ReactElement {
             )}
           </div>
 
-          {hasAddedLiquidity && (
-            <div className={styles.transactions}>
-              <h3 className={styles.title}>Your Transactions</h3>
-              <PoolTransactions poolAddress={price?.address} minimal />
-            </div>
-          )}
+          <div className={styles.transactions}>
+            <h3 className={styles.title}>Your Pool Transactions</h3>
+            <PoolTransactions poolAddress={price?.address} minimal />
+          </div>
         </>
       )}
     </>

--- a/src/components/organisms/AssetActions/Pool/index.tsx
+++ b/src/components/organisms/AssetActions/Pool/index.tsx
@@ -72,16 +72,12 @@ export default function Pool({ ddo }: { ddo: DDO }): ReactElement {
   const [refreshPool, setRefreshPool] = useState(false)
 
   useEffect(() => {
-    const hasAddedLiquidity =
-      userLiquidity && (userLiquidity.ocean > 0 || userLiquidity.datatoken > 0)
-    setHasAddedLiquidity(hasAddedLiquidity)
-
     const poolShare =
       price?.ocean &&
       price?.datatoken &&
-      userLiquidity &&
-      ((Number(poolTokens) / Number(totalPoolTokens)) * 100).toFixed(2)
+      ((Number(poolTokens) / Number(totalPoolTokens)) * 100).toFixed(5)
     setPoolShare(poolShare)
+    setHasAddedLiquidity(Number(poolShare) > 0)
 
     const totalUserLiquidityInOcean =
       userLiquidity?.ocean + userLiquidity?.datatoken * price?.value
@@ -130,15 +126,13 @@ export default function Pool({ ddo }: { ddo: DDO }): ReactElement {
         //
         // Get everything the creator put into the pool
         //
-
         const creatorPoolTokens = await ocean.pool.sharesBalance(
           ddo.publicKey[0].owner,
           price.address
         )
         setCreatorPoolTokens(creatorPoolTokens)
 
-        // calculate creator's provided liquidity based on pool tokens
-
+        // Calculate creator's provided liquidity based on pool tokens
         const creatorOceanBalance =
           (Number(creatorPoolTokens) / Number(totalPoolTokens)) * price.ocean
 

--- a/src/components/organisms/AssetActions/Pool/index.tsx
+++ b/src/components/organisms/AssetActions/Pool/index.tsx
@@ -45,7 +45,7 @@ export default function Pool({ ddo }: { ddo: DDO }): ReactElement {
   const content = data.content.edges[0].node.childContentJson.pool
 
   const { ocean, accountId, networkId } = useOcean()
-  const { price, refreshPrice } = useMetadata(ddo)
+  const { price, refreshPrice, owner } = useMetadata(ddo)
   const { dtSymbol } = usePricing(ddo)
 
   const [poolTokens, setPoolTokens] = useState<string>()
@@ -127,7 +127,7 @@ export default function Pool({ ddo }: { ddo: DDO }): ReactElement {
         // Get everything the creator put into the pool
         //
         const creatorPoolTokens = await ocean.pool.sharesBalance(
-          ddo.publicKey[0].owner,
+          owner,
           price.address
         )
         setCreatorPoolTokens(creatorPoolTokens)

--- a/src/components/organisms/AssetActions/Pool/index.tsx
+++ b/src/components/organisms/AssetActions/Pool/index.tsx
@@ -283,10 +283,12 @@ export default function Pool({ ddo }: { ddo: DDO }): ReactElement {
             )}
           </div>
 
-          <div className={styles.transactions}>
-            <h3 className={styles.title}>Your Pool Transactions</h3>
-            <PoolTransactions poolAddress={price?.address} minimal />
-          </div>
+          {accountId && (
+            <div className={styles.transactions}>
+              <h3 className={styles.title}>Your Pool Transactions</h3>
+              <PoolTransactions poolAddress={price?.address} minimal />
+            </div>
+          )}
         </>
       )}
     </>

--- a/src/components/organisms/AssetContent/index.module.css
+++ b/src/components/organisms/AssetContent/index.module.css
@@ -20,9 +20,7 @@
     grid-template-columns: 1.5fr 1fr;
   }
 
-  .sticky {
-    position: sticky;
-    top: calc(var(--spacer) / 2);
+  .actions {
     margin-top: var(--spacer);
   }
 }

--- a/src/components/organisms/AssetContent/index.tsx
+++ b/src/components/organisms/AssetContent/index.tsx
@@ -106,10 +106,8 @@ export default function AssetContent({
         </div>
       </div>
 
-      <div>
-        <div className={styles.sticky}>
-          <AssetActions ddo={ddo} />
-        </div>
+      <div className={styles.actions}>
+        <AssetActions ddo={ddo} />
       </div>
     </article>
   )

--- a/src/components/organisms/PoolTransactions.tsx
+++ b/src/components/organisms/PoolTransactions.tsx
@@ -71,13 +71,12 @@ export default function PoolTransactions({
       }
     },
     {
-      ...(!minimal && {
-        name: 'Data Set',
-        selector: function getAssetRow(row: PoolTransaction) {
-          const did = row.dtAddress.replace('0x', 'did:op:')
-          return <AssetTitle did={did} />
-        }
-      })
+      name: 'Data Set',
+      selector: function getAssetRow(row: PoolTransaction) {
+        const did = row.dtAddress.replace('0x', 'did:op:')
+        return <AssetTitle did={did} />
+      },
+      omit: minimal
     },
     {
       name: 'Time',
@@ -94,6 +93,8 @@ export default function PoolTransactions({
       isLoading={isLoading}
       noTableHead={minimal}
       dense={minimal}
+      pagination={minimal ? logs?.length >= 4 : logs?.length >= 9}
+      paginationPerPage={minimal ? 5 : 10}
     />
   )
 }

--- a/src/components/pages/History/index.tsx
+++ b/src/components/pages/History/index.tsx
@@ -2,7 +2,7 @@ import React, { ReactElement, ReactNode } from 'react'
 import ComputeJobs from './ComputeJobs'
 import styles from './index.module.css'
 import PoolShares from './PoolShares'
-import PoolTransactions from '../../organisms/PoolTransactions'
+import PoolTransactions from '../../molecules/PoolTransactions'
 import PublishedList from './PublishedList'
 
 const sections = [

--- a/src/components/pages/History/index.tsx
+++ b/src/components/pages/History/index.tsx
@@ -2,7 +2,7 @@ import React, { ReactElement, ReactNode } from 'react'
 import ComputeJobs from './ComputeJobs'
 import styles from './index.module.css'
 import PoolShares from './PoolShares'
-import PoolTransactions from './PoolTransactions'
+import PoolTransactions from '../../organisms/PoolTransactions'
 import PublishedList from './PublishedList'
 
 const sections = [


### PR DESCRIPTION
closes #185

With toggle pattern for less busy interface, and more performant initial pool widget loading.

Default:
<img width="471" alt="Screen Shot 2020-11-02 at 16 20 51" src="https://user-images.githubusercontent.com/90316/97885297-76dc2100-1d27-11eb-9304-dfadf74c6764.png">

Open:
<img width="491" alt="Screen Shot 2020-11-02 at 16 21 02" src="https://user-images.githubusercontent.com/90316/97885308-7a6fa800-1d27-11eb-98ca-16b50f6db630.png">

