### PR TITLE
Context warnings, more terms links

### DIFF
--- a/content/pages/publish.json
+++ b/content/pages/publish.json
@@ -1,6 +1,7 @@
 {
   "title": "Publish",
   "description": "Highlight the important features of your data set to make it more discoverable and catch the interest of data consumers.",
+  "warning": "Given the beta status, publishing on Rinkeby first is strongly recommended. [Learn about the market](https://oceanprotocol.com/technology/marketplaces).",
   "form": {
     "title": "Publish",
     "data": [

--- a/content/pages/publish.json
+++ b/content/pages/publish.json
@@ -1,7 +1,7 @@
 {
   "title": "Publish",
   "description": "Highlight the important features of your data set to make it more discoverable and catch the interest of data consumers.",
-  "warning": "Given the beta status, publishing on Rinkeby first is strongly recommended. [Learn about the market](https://oceanprotocol.com/technology/marketplaces).",
+  "warning": "Given the beta status, publishing on Rinkeby first is strongly recommended. Please familiarize yourself with [the market](https://oceanprotocol.com/technology/marketplaces), [the risks](https://blog.oceanprotocol.com/on-staking-on-data-in-ocean-market-3d8e09eb0a13), and the [Terms of Use](/terms).",
   "form": {
     "title": "Publish",
     "data": [

--- a/content/site.json
+++ b/content/site.json
@@ -15,6 +15,7 @@
         "name": "History",
         "link": "/history"
       }
-    ]
+    ],
+    "warning": "We are in beta. Please familiarize yourself with [the market](https://oceanprotocol.com/technology/marketplaces), [the risks](https://blog.oceanprotocol.com/on-staking-on-data-in-ocean-market-3d8e09eb0a13), and the [Terms of Use](/terms)."
   }
 }

--- a/src/components/Layout.module.css
+++ b/src/components/Layout.module.css
@@ -19,3 +19,7 @@
   /* sticky footer technique */
   flex: 1;
 }
+
+.banner {
+  margin-bottom: -2rem !important;
+}

--- a/src/components/Layout.module.css
+++ b/src/components/Layout.module.css
@@ -14,7 +14,7 @@
 }
 
 .main {
-  padding: var(--spacer) 0 calc(var(--spacer) * 2) 0;
+  padding: calc(var(--spacer) * 2) 0;
 
   /* sticky footer technique */
   flex: 1;

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -30,6 +30,14 @@ export default function Layout({
 
       <Header />
 
+      {uri === '/' && (
+        <Alert
+          text="We are in beta. Please familiarize yourself with [the market](https://oceanprotocol.com/technology/marketplaces), [the risks](https://blog.oceanprotocol.com/on-staking-on-data-in-ocean-market-3d8e09eb0a13), and the [Terms of Use](/terms)."
+          state="info"
+          className={styles.banner}
+        />
+      )}
+
       <main className={styles.main}>
         <Container>
           {title && !noPageHeader && (

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -6,6 +6,7 @@ import styles from './Layout.module.css'
 import Seo from './atoms/Seo'
 import Container from './atoms/Container'
 import Alert from './atoms/Alert'
+import { useSiteMetadata } from '../hooks/useSiteMetadata'
 
 export interface LayoutProps {
   children: ReactNode
@@ -24,6 +25,8 @@ export default function Layout({
   noPageHeader,
   headerCenter
 }: LayoutProps): ReactElement {
+  const { warning } = useSiteMetadata()
+
   return (
     <div className={styles.app}>
       <Seo title={title} description={description} uri={uri} />
@@ -31,11 +34,7 @@ export default function Layout({
       <Header />
 
       {uri === '/' && (
-        <Alert
-          text="We are in beta. Please familiarize yourself with [the market](https://oceanprotocol.com/technology/marketplaces), [the risks](https://blog.oceanprotocol.com/on-staking-on-data-in-ocean-market-3d8e09eb0a13), and the [Terms of Use](/terms)."
-          state="info"
-          className={styles.banner}
-        />
+        <Alert text={warning} state="info" className={styles.banner} />
       )}
 
       <main className={styles.main}>

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -30,11 +30,6 @@ export default function Layout({
 
       <Header />
 
-      <Alert
-        text="Given the beta status, publishing on Rinkeby first is strongly recommended. [Learn about the market](https://oceanprotocol.com/technology/marketplaces)."
-        state="info"
-      />
-
       <main className={styles.main}>
         <Container>
           {title && !noPageHeader && (

--- a/src/components/organisms/Footer.tsx
+++ b/src/components/organisms/Footer.tsx
@@ -2,6 +2,7 @@ import React, { ReactElement } from 'react'
 import styles from './Footer.module.css'
 import Markdown from '../atoms/Markdown'
 import { useSiteMetadata } from '../../hooks/useSiteMetadata'
+import { Link } from 'gatsby'
 
 export default function Footer(): ReactElement {
   const { copyright } = useSiteMetadata()
@@ -10,7 +11,9 @@ export default function Footer(): ReactElement {
   return (
     <footer className={styles.footer}>
       <div className={styles.content}>
-        © {year} <Markdown text={copyright} />
+        © {year} <Markdown text={copyright} /> — <Link to="/terms">Terms</Link>
+        {' — '}
+        <a href="https://oceanprotocol.com/privacy">Privacy</a>
       </div>
     </footer>
   )

--- a/src/components/pages/Publish/index.module.css
+++ b/src/components/pages/Publish/index.module.css
@@ -4,6 +4,11 @@
   position: relative;
 }
 
+.alert {
+  margin-bottom: var(--spacer);
+  margin-left: 0;
+}
+
 @media (min-width: 55rem) {
   .grid {
     /* lazy golden ratio */

--- a/src/components/pages/Publish/index.module.css
+++ b/src/components/pages/Publish/index.module.css
@@ -4,7 +4,8 @@
   position: relative;
 }
 
-.alert {
+.alert,
+div.alert {
   margin-bottom: var(--spacer);
   margin-left: 0;
 }

--- a/src/components/pages/Publish/index.tsx
+++ b/src/components/pages/Publish/index.tsx
@@ -21,7 +21,7 @@ const formName = 'ocean-publish-form'
 export default function PublishPage({
   content
 }: {
-  content: { form: FormContent }
+  content: { warning: string; form: FormContent }
 }): ReactElement {
   const { debug } = useUserPreferences()
   const { publish, publishError, isLoading, publishStepText } = usePublish()
@@ -100,7 +100,7 @@ export default function PublishPage({
           ) : (
             <>
               <Alert
-                text="Given the beta status, publishing on Rinkeby first is strongly recommended. [Learn about the market](https://oceanprotocol.com/technology/marketplaces)."
+                text={content.warning}
                 state="info"
                 className={styles.alert}
               />

--- a/src/components/pages/Publish/index.tsx
+++ b/src/components/pages/Publish/index.tsx
@@ -14,6 +14,7 @@ import { DDO, Logger, Metadata } from '@oceanprotocol/lib'
 import { Persist } from '../../atoms/FormikPersist'
 import Debug from './Debug'
 import Feedback from './Feedback'
+import Alert from '../../atoms/Alert'
 
 const formName = 'ocean-publish-form'
 
@@ -97,15 +98,23 @@ export default function PublishPage({
               setError={setError}
             />
           ) : (
-            <article className={styles.grid}>
-              <FormPublish content={content.form} />
-              <aside>
-                <div className={styles.sticky}>
-                  <Preview values={values} />
-                  <Web3Feedback />
-                </div>
-              </aside>
-            </article>
+            <>
+              <Alert
+                text="Given the beta status, publishing on Rinkeby first is strongly recommended. [Learn about the market](https://oceanprotocol.com/technology/marketplaces)."
+                state="info"
+                className={styles.alert}
+              />
+              <article className={styles.grid}>
+                <FormPublish content={content.form} />
+
+                <aside>
+                  <div className={styles.sticky}>
+                    <Preview values={values} />
+                    <Web3Feedback />
+                  </div>
+                </aside>
+              </article>
+            </>
           )}
 
           {debug === true && <Debug values={values} />}

--- a/src/hooks/useSiteMetadata.ts
+++ b/src/hooks/useSiteMetadata.ts
@@ -13,6 +13,7 @@ const query = graphql`
           name
           link
         }
+        warning
         appConfig {
           infuraProjectId
           network

--- a/src/pages/publish.tsx
+++ b/src/pages/publish.tsx
@@ -22,6 +22,7 @@ export const contentQuery = graphql`
           childPagesJson {
             title
             description
+            warning
             form {
               title
               data {


### PR DESCRIPTION
more context-based warnings, only warn right before users interact with their money, and on main page:

<img width="1162" alt="Screen Shot 2020-11-03 at 13 00 25" src="https://user-images.githubusercontent.com/90316/97983031-f07e1880-1dd4-11eb-862f-f5594e8002cf.png">

<img width="950" alt="Screen Shot 2020-11-03 at 13 39 33" src="https://user-images.githubusercontent.com/90316/97986457-0510df80-1dda-11eb-9853-517e9a35d310.png">

<img width="480" alt="Screen Shot 2020-11-03 at 13 01 11" src="https://user-images.githubusercontent.com/90316/97983064-fbd14400-1dd4-11eb-825f-92630b3c413d.png">

And for the lawyers, quick simple footer links:
<img width="638" alt="Screen Shot 2020-11-03 at 13 17 14" src="https://user-images.githubusercontent.com/90316/97984359-f8d75300-1dd6-11eb-961c-9c35d7f70e1c.png">


closes #170