### PR TITLE
fix pool share links

### DIFF
--- a/src/components/pages/History/PoolShares.tsx
+++ b/src/components/pages/History/PoolShares.tsx
@@ -30,7 +30,13 @@ const columns = [
     selector: function getAssetRow(row: Asset) {
       const { attributes } = row.ddo.findServiceByType('metadata')
       const { owner } = row.ddo.publicKey[0]
-      return <AssetTitle title={attributes.main.name} owner={owner} />
+      return (
+        <AssetTitle
+          did={row.ddo.id}
+          title={attributes.main.name}
+          owner={owner}
+        />
+      )
     },
     grow: 2
   },


### PR DESCRIPTION
Data set titles in the pool shares table were not getting the right link.