### PR TITLE
Remove slider quick wins

### DIFF
--- a/src/components/atoms/Input/InputElement.module.css
+++ b/src/components/atoms/Input/InputElement.module.css
@@ -211,16 +211,28 @@
 }
 
 input[type='range'] {
-  background: none;
+  background: transparent;
+  appearance: none;
 }
 
 input[type='range']:focus {
   outline: none;
 }
 
-input[type='range']::-webkit-slider-thumb,
+/* Selectors need to be split up to work in both engines */
+input[type='range']::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  margin-top: -0.5rem;
+  background: var(--brand-gradient);
+  border: 2px solid var(--border-color);
+  width: var(--font-size-h4);
+  height: var(--font-size-h4);
+  border-radius: 50%;
+  cursor: pointer;
+  box-shadow: 0 2px 9px 0 rgba(0, 0, 0, 0.2);
+}
+
 input[type='range']::-moz-range-thumb {
-  appearance: none;
   background: var(--brand-gradient);
   border: 2px solid var(--border-color);
   width: var(--font-size-large);
@@ -230,7 +242,14 @@ input[type='range']::-moz-range-thumb {
   box-shadow: 0 2px 9px 0 rgba(0, 0, 0, 0.2);
 }
 
-input[type='range']::-webkit-slider-runnable-track,
+input[type='range']::-webkit-slider-runnable-track {
+  margin-top: -1rem;
+  background: var(--border-color);
+  border-radius: var(--border-radius);
+  height: 0.3rem;
+  border: none;
+}
+
 input[type='range']::-moz-range-track {
   background: var(--border-color);
   border-radius: var(--border-radius);

--- a/src/components/organisms/AssetActions/Pool/Remove.module.css
+++ b/src/components/organisms/AssetActions/Pool/Remove.module.css
@@ -31,15 +31,6 @@
   margin-right: -2rem;
 }
 
-.range button {
-  margin-top: calc(var(--spacer) / 4);
-  margin-bottom: 0;
-  position: absolute;
-  bottom: 1rem;
-  right: 2rem;
-  font-size: var(--font-size-mini);
-}
-
 .slider {
   position: relative;
   z-index: 1;
@@ -48,10 +39,17 @@
 .maximum {
   position: absolute;
   right: -1.5rem;
-  bottom: 1.5rem;
-  font-size: var(--font-size-small);
-  z-index: 0;
-  pointer-events: none;
+  bottom: 2rem;
+  font-size: var(--font-size-mini);
+}
+
+.toggle {
+  margin-top: calc(var(--spacer) / 4);
+  margin-bottom: 0;
+  position: absolute;
+  bottom: 1rem;
+  right: 2rem;
+  font-size: var(--font-size-mini);
 }
 
 .output {

--- a/src/components/organisms/AssetActions/Pool/Remove.module.css
+++ b/src/components/organisms/AssetActions/Pool/Remove.module.css
@@ -2,6 +2,7 @@
   composes: addInput from './Add/index.module.css';
   padding-left: calc(var(--spacer) * 2);
   padding-right: calc(var(--spacer) * 2);
+  padding-bottom: calc(var(--spacer) / 2);
 }
 
 .userLiquidity {
@@ -38,18 +39,18 @@
 
 .maximum {
   position: absolute;
-  right: -1.5rem;
+  right: -2rem;
   bottom: 2rem;
   font-size: var(--font-size-mini);
+  min-width: 5rem;
+  text-align: center;
 }
 
 .toggle {
-  margin-top: calc(var(--spacer) / 4);
+  margin-top: calc(var(--spacer) / 2);
   margin-bottom: 0;
-  position: absolute;
-  bottom: 1rem;
-  right: 2rem;
   font-size: var(--font-size-mini);
+  margin-bottom: -2rem;
 }
 
 .output {

--- a/src/components/organisms/AssetActions/Pool/Remove.tsx
+++ b/src/components/organisms/AssetActions/Pool/Remove.tsx
@@ -100,45 +100,15 @@ export default function Remove({
     }
   }
 
-  // Set amountPoolShares based on set slider value
-  function handleAmountPercentChange(e: ChangeEvent<HTMLInputElement>) {
-    setAmountPercent(e.target.value)
-    if (!poolTokens) return
-
-    const amountPoolShares = (Number(e.target.value) / 100) * Number(poolTokens)
-    setAmountPoolShares(`${amountPoolShares}`)
-  }
-
-  function handleMaxButton(e: ChangeEvent<HTMLInputElement>) {
-    e.preventDefault()
-    setAmountPercent('100')
-    setAmountPoolShares(poolTokens)
-  }
-
-  function handleAdvancedButton(e: FormEvent<HTMLButtonElement>) {
-    e.preventDefault()
-    setIsAdvanced(!isAdvanced)
-
-    setAmountPoolShares(`0`)
-    setAmountPercent('0')
-    setAmountOcean('0')
-    setAmountMaxPercent('100')
-
-    if (isAdvanced === true) {
-      setAmountDatatoken('0')
-    }
-  }
-
   // Get and set max percentage
   useEffect(() => {
-    if (!ocean || !poolTokens || isAdvanced === true) return
+    if (!ocean || !poolTokens) return
 
     async function getMax() {
-      const amountMaxPercent = await getMaxPercentRemove(
-        ocean,
-        poolAddress,
-        poolTokens
-      )
+      const amountMaxPercent =
+        isAdvanced === true
+          ? '100'
+          : await getMaxPercentRemove(ocean, poolAddress, poolTokens)
       setAmountMaxPercent(amountMaxPercent)
     }
     getMax()
@@ -176,6 +146,37 @@ export default function Remove({
     totalPoolTokens
   ])
 
+  // Set amountPoolShares based on set slider value
+  function handleAmountPercentChange(e: ChangeEvent<HTMLInputElement>) {
+    setAmountPercent(e.target.value)
+    if (!poolTokens) return
+
+    const amountPoolShares = (Number(e.target.value) / 100) * Number(poolTokens)
+    setAmountPoolShares(`${amountPoolShares}`)
+  }
+
+  function handleMaxButton(e: ChangeEvent<HTMLInputElement>) {
+    e.preventDefault()
+    setAmountPercent(amountMaxPercent)
+
+    const amountPoolShares =
+      (Number(amountMaxPercent) / 100) * Number(poolTokens)
+    setAmountPoolShares(`${amountPoolShares}`)
+  }
+
+  function handleAdvancedButton(e: FormEvent<HTMLButtonElement>) {
+    e.preventDefault()
+    setIsAdvanced(!isAdvanced)
+
+    setAmountPoolShares('0')
+    setAmountPercent('0')
+    setAmountOcean('0')
+
+    if (isAdvanced === true) {
+      setAmountDatatoken('0')
+    }
+  }
+
   return (
     <div className={styles.remove}>
       <Header title={content.title} backAction={() => setShowRemove(false)} />
@@ -204,7 +205,7 @@ export default function Remove({
               className={styles.maximum}
               onClick={handleMaxButton}
             >
-              {isAdvanced === false ? `${amountMaxPercent}% max` : 'max'}
+              {`${amountMaxPercent}% max`}
             </Button>
           </div>
 

--- a/src/components/organisms/AssetActions/Pool/Remove.tsx
+++ b/src/components/organisms/AssetActions/Pool/Remove.tsx
@@ -104,6 +104,11 @@ export default function Remove({
     setAmountPercent(e.target.value)
   }
 
+  function handleMaxButton(e: ChangeEvent<HTMLInputElement>) {
+    e.preventDefault()
+    setAmountPercent('100')
+  }
+
   function handleAdvancedButton(e: FormEvent<HTMLButtonElement>) {
     e.preventDefault()
     setIsAdvanced(!isAdvanced)
@@ -111,6 +116,7 @@ export default function Remove({
 
   useEffect(() => {
     if (!ocean || !poolTokens) return
+
     async function resetValues() {
       setAmountPoolShares(`0`)
       setAmountPercent('0')
@@ -130,7 +136,7 @@ export default function Remove({
       }
     }
     resetValues()
-  }, [isAdvanced])
+  }, [ocean, isAdvanced, poolAddress, poolTokens])
 
   // Check and set outputs when percentage changes
   useEffect(() => {
@@ -191,16 +197,24 @@ export default function Remove({
               onChange={handleAmountPercentChange}
             />
             {isAdvanced === false && (
-              <span
+              <Button
+                style="text"
+                size="small"
                 className={styles.maximum}
-              >{`${amountMaxPercent}% max.`}</span>
+                onClick={handleMaxButton}
+              >{`${amountMaxPercent}% max`}</Button>
             )}
           </div>
 
           <FormHelp>
             {isAdvanced === true ? content.advanced : content.simple}
           </FormHelp>
-          <Button style="text" size="small" onClick={handleAdvancedButton}>
+          <Button
+            style="text"
+            size="small"
+            onClick={handleAdvancedButton}
+            className={styles.toggle}
+          >
             {isAdvanced === true ? 'Simple' : 'Advanced'}
           </Button>
         </div>

--- a/src/components/organisms/AssetActions/Pool/Remove.tsx
+++ b/src/components/organisms/AssetActions/Pool/Remove.tsx
@@ -118,7 +118,6 @@ export default function Remove({
 
   const getValues = useRef(
     debounce(async (newAmountPoolShares, isAdvanced) => {
-      console.log('values', newAmountPoolShares, isAdvanced)
       if (isAdvanced === true) {
         const tokens = await ocean.pool.getTokensRemovedforPoolShares(
           poolAddress,

--- a/src/components/organisms/AssetActions/Pool/Remove.tsx
+++ b/src/components/organisms/AssetActions/Pool/Remove.tsx
@@ -4,7 +4,6 @@ import React, {
   ChangeEvent,
   useEffect,
   FormEvent,
-  useCallback,
   useRef
 } from 'react'
 import styles from './Remove.module.css'
@@ -20,7 +19,7 @@ import { getMaxPercentRemove } from './utils'
 import { graphql, useStaticQuery } from 'gatsby'
 import PriceUnit from '../../../atoms/Price/PriceUnit'
 import debounce from 'lodash.debounce'
-import { throttle } from 'lodash'
+
 const contentQuery = graphql`
   query PoolRemoveQuery {
     content: allFile(filter: { relativePath: { eq: "price.json" } }) {
@@ -133,7 +132,7 @@ export default function Remove({
         newAmountPoolShares
       )
       setAmountOcean(amountOcean)
-    }, 300)
+    }, 150)
   )
   // Check and set outputs when amountPoolShares changes
   useEffect(() => {

--- a/src/components/organisms/AssetActions/Pool/utils.ts
+++ b/src/components/organisms/AssetActions/Pool/utils.ts
@@ -1,11 +1,10 @@
 import { Ocean } from '@oceanprotocol/lib'
 
-export async function getMaxValuesRemove(
+export async function getMaxPercentRemove(
   ocean: Ocean,
   poolAddress: string,
-  poolTokens: string,
-  amountPoolShares: string
-): Promise<{ amountMaxPercent: string; amountOcean: string }> {
+  poolTokens: string
+): Promise<string> {
   const amountMaxOcean = await ocean.pool.getOceanMaxRemoveLiquidity(
     poolAddress
   )
@@ -22,10 +21,5 @@ export async function getMaxValuesRemove(
     amountMaxPercent = '100'
   }
 
-  const amountOcean = await ocean.pool.getOceanRemovedforPoolShares(
-    poolAddress,
-    amountPoolShares
-  )
-
-  return { amountMaxPercent, amountOcean }
+  return amountMaxPercent
 }


### PR DESCRIPTION
Without switching to new component some quick wins addressing #196 to make the slider a bit more bearable:

- Address main pain point: turn the maximum % display into a max button:

  <img width="464" alt="Screen Shot 2020-11-06 at 23 24 14" src="https://user-images.githubusercontent.com/90316/98420309-3235ea00-2087-11eb-8942-25cba232e1de.png">

- Make custom slider styles appear in Chrome too
- Majority of weirdness on simple screen comes from the multiple calls happening when slider is moved, and then when multiple values are updated in component, effects fire too often while the calls are still running, all leading to this number sluggishness when moving the slider. 
- Addressed this a bit by splitting up and reducing the effect usage and doing more directly in the `onChange` handlers. 
- And finally split up that method with the 4 pool calls, this was blocking getting `amountOcean`, the displayed value in UI. All not perfect but a bit better before we switch to some other component.

closes #196