### PR TITLE
More footer data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ storybook-static
 public/storybook
 .artifacts
 .vercel
+repo-metadata.json

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,6 +1,10 @@
 const path = require('path')
 const createFields = require('./gatsby/createFields')
 const createMarkdownPages = require('./gatsby/createMarkdownPages')
+const execSync = require('child_process').execSync
+
+// Write out repo metadata
+execSync(`node ./scripts/write-repo-metadata > repo-metadata.json`)
 
 exports.onCreateNode = ({ node, actions, getNode }) => {
   createFields(node, actions, getNode)

--- a/package.json
+++ b/package.json
@@ -11,12 +11,13 @@
     "jest": "NODE_ENV=test jest -c tests/unit/jest.config.js",
     "test": "npm run lint && npm run jest",
     "test:watch": "npm run lint && npm run jest -- --watch",
-    "lint": "eslint --ignore-path .gitignore --ext .js --ext .ts --ext .tsx . && npm run type-check",
+    "lint": "npm run write:repoMetadata && eslint --ignore-path .gitignore --ext .js --ext .ts --ext .tsx . && npm run type-check",
     "format": "prettier --ignore-path .gitignore './**/*.{css,yml,js,ts,tsx,json}' --write",
     "type-check": "tsc --noEmit",
     "analyze": "npm run build && source-map-explorer 'public/*.js'",
     "storybook": "start-storybook -p 4000 -c .storybook",
-    "storybook:build": "build-storybook -c .storybook -o public/storybook"
+    "storybook:build": "build-storybook -c .storybook -o public/storybook",
+    "write:repoMetadata": "node ./scripts/write-repo-metadata > repo-metadata.json"
   },
   "dependencies": {
     "@coingecko/cryptoformat": "^0.4.2",

--- a/scripts/write-repo-metadata.js
+++ b/scripts/write-repo-metadata.js
@@ -3,6 +3,11 @@
 
 const execSync = require('child_process').execSync
 
+//
+// VERCEL_GITHUB_COMMIT_REF & VERCEL_GITHUB_COMMIT_SHA need to be added with empty
+// values in Vercel environment variables, making them available to builds.
+// https://vercel.com/docs/build-step#system-environment-variables
+//
 process.stdout.write(
   JSON.stringify(
     {

--- a/scripts/write-repo-metadata.js
+++ b/scripts/write-repo-metadata.js
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+'use strict'
+
+const execSync = require('child_process').execSync
+
+process.stdout.write(
+  JSON.stringify(
+    {
+      version: require('../package.json').version,
+      branch: process.env.VERCEL_GITHUB_COMMIT_REF || 'dev',
+      commit:
+        process.env.VERCEL_GITHUB_COMMIT_SHA ||
+        execSync(`git rev-parse HEAD`).toString().trim()
+    },
+    null,
+    '  '
+  )
+)

--- a/src/components/atoms/BuildId.module.css
+++ b/src/components/atoms/BuildId.module.css
@@ -1,0 +1,6 @@
+.buildId {
+  display: inline-block;
+  font-size: var(--font-size-mini);
+  margin-bottom: var(--spacer);
+  font-family: var(--font-family-monospace);
+}

--- a/src/components/atoms/BuildId.tsx
+++ b/src/components/atoms/BuildId.tsx
@@ -1,0 +1,23 @@
+import React, { ReactElement } from 'react'
+import repoMetadata from '../../../repo-metadata.json'
+import styles from './BuildId.module.css'
+
+export default function BuildId(): ReactElement {
+  const commitBranch = repoMetadata.branch
+  const commitId = repoMetadata.commit
+  const isMainBranch = commitBranch === 'main'
+
+  return (
+    <a
+      className={styles.buildId}
+      href={`https://github.com/oceanprotocol/market/tree/${
+        isMainBranch ? commitId : commitBranch
+      }`}
+      target="_blank"
+      rel="noreferrer"
+      title="Build ID referring to the linked commit hash."
+    >
+      {isMainBranch ? commitId.substring(0, 7) : commitBranch}
+    </a>
+  )
+}

--- a/src/components/molecules/MarketStats.module.css
+++ b/src/components/molecules/MarketStats.module.css
@@ -1,16 +1,14 @@
 .stats {
   margin-bottom: calc(var(--spacer) * 2);
-  font-size: var(--font-size-base);
+  font-size: var(--font-size-small);
+  line-height: 2;
 }
 
 .stats > div > div {
   display: inline-block;
 }
 
-.stats > div strong {
-  font-size: var(--font-size-base) !important;
-}
-
 .total {
   color: var(--color-secondary) !important;
+  font-size: var(--font-size-small) !important;
 }

--- a/src/components/molecules/MarketStats.tsx
+++ b/src/components/molecules/MarketStats.tsx
@@ -57,14 +57,21 @@ export default function MarketStats(): ReactElement {
 
   return (
     <div className={styles.stats} ref={ref}>
-      Total of <strong>{stats?.datasets.total}</strong> data sets & datatokens
-      published by <strong>{stats?.owners}</strong> accounts.
+      Total of <strong>{stats?.datasets.total}</strong> data sets & unique
+      datatokens published by <strong>{stats?.owners}</strong> accounts.
       <br />
       <PriceUnit
         price={`${stats?.ocean}`}
         small
         className={styles.total}
         conversion
+      />{' '}
+      and{' '}
+      <PriceUnit
+        price={`${stats?.datatoken}`}
+        symbol="datatokens"
+        small
+        className={styles.total}
       />{' '}
       in <strong>{stats?.datasets.pools}</strong> data set pools.
       <br />

--- a/src/components/organisms/Footer.module.css
+++ b/src/components/organisms/Footer.module.css
@@ -23,10 +23,3 @@
 .content a:focus {
   color: var(--color-primary);
 }
-
-.commitId {
-  display: inline-block;
-  font-size: var(--font-size-mini);
-  margin-bottom: var(--spacer);
-  font-family: var(--font-family-monospace);
-}

--- a/src/components/organisms/Footer.module.css
+++ b/src/components/organisms/Footer.module.css
@@ -14,3 +14,19 @@
 .content p {
   display: inline;
 }
+
+.content a {
+  color: inherit;
+}
+
+.content a:hover,
+.content a:focus {
+  color: var(--color-primary);
+}
+
+.commitId {
+  display: inline-block;
+  font-size: var(--font-size-mini);
+  margin-bottom: var(--spacer);
+  font-family: var(--font-family-monospace);
+}

--- a/src/components/organisms/Footer.tsx
+++ b/src/components/organisms/Footer.tsx
@@ -24,6 +24,7 @@ export default function Footer(): ReactElement {
           }`}
           target="_blank"
           rel="noreferrer"
+          title="Build ID referring to the linked commit hash."
         >
           {isMainBranch ? commitId.substring(0, 7) : commitBranch}
         </a>

--- a/src/components/organisms/Footer.tsx
+++ b/src/components/organisms/Footer.tsx
@@ -4,30 +4,16 @@ import Markdown from '../atoms/Markdown'
 import { useSiteMetadata } from '../../hooks/useSiteMetadata'
 import { Link } from 'gatsby'
 import MarketStats from '../molecules/MarketStats'
-import repoMetadata from '../../../repo-metadata.json'
+import BuildId from '../atoms/BuildId'
 
 export default function Footer(): ReactElement {
   const { copyright } = useSiteMetadata()
   const year = new Date().getFullYear()
 
-  const commitBranch = repoMetadata.branch
-  const commitId = repoMetadata.commit
-  const isMainBranch = commitBranch === 'main'
-
   return (
     <footer className={styles.footer}>
       <div className={styles.content}>
-        <a
-          className={styles.commitId}
-          href={`https://github.com/oceanprotocol/market/tree/${
-            isMainBranch ? commitId : commitBranch
-          }`}
-          target="_blank"
-          rel="noreferrer"
-          title="Build ID referring to the linked commit hash."
-        >
-          {isMainBranch ? commitId.substring(0, 7) : commitBranch}
-        </a>
+        <BuildId />
         <MarketStats />© {year} <Markdown text={copyright} /> —{' '}
         <Link to="/terms">Terms</Link>
         {' — '}

--- a/src/components/organisms/Footer.tsx
+++ b/src/components/organisms/Footer.tsx
@@ -4,13 +4,14 @@ import Markdown from '../atoms/Markdown'
 import { useSiteMetadata } from '../../hooks/useSiteMetadata'
 import { Link } from 'gatsby'
 import MarketStats from '../molecules/MarketStats'
+import repoMetadata from '../../../repo-metadata.json'
 
 export default function Footer(): ReactElement {
   const { copyright } = useSiteMetadata()
   const year = new Date().getFullYear()
 
-  const commitBranch = process.env.VERCEL_GITHUB_COMMIT_REF || 'dev'
-  const commitId = process.env.VERCEL_GITHUB_COMMIT_SHA
+  const commitBranch = repoMetadata.branch
+  const commitId = repoMetadata.commit
   const isMainBranch = commitBranch === 'main'
 
   return (

--- a/src/components/organisms/Footer.tsx
+++ b/src/components/organisms/Footer.tsx
@@ -9,9 +9,23 @@ export default function Footer(): ReactElement {
   const { copyright } = useSiteMetadata()
   const year = new Date().getFullYear()
 
+  const commitBranch = process.env.VERCEL_GITHUB_COMMIT_REF || 'dev'
+  const commitId = process.env.VERCEL_GITHUB_COMMIT_SHA
+  const isMainBranch = commitBranch === 'main'
+
   return (
     <footer className={styles.footer}>
       <div className={styles.content}>
+        <a
+          className={styles.commitId}
+          href={`https://github.com/oceanprotocol/market/tree/${
+            isMainBranch ? commitId : commitBranch
+          }`}
+          target="_blank"
+          rel="noreferrer"
+        >
+          {isMainBranch ? commitId.substring(0, 7) : commitBranch}
+        </a>
         <MarketStats />© {year} <Markdown text={copyright} /> —{' '}
         <Link to="/terms">Terms</Link>
         {' — '}


### PR DESCRIPTION
- output total datatoken liquidity in footer stats
- add build id to footer

The build id on deploy previews is the branch name, linked to respective branch on GitHub:

<img width="638" alt="Screen Shot 2020-11-08 at 14 42 25" src="https://user-images.githubusercontent.com/90316/98466572-a4feac80-21d0-11eb-9a04-39d420c1c917.png">

Locally, it will output `dev`, linked to the commit on GitHub:

<img width="657" alt="Screen Shot 2020-11-08 at 14 43 53" src="https://user-images.githubusercontent.com/90316/98466614-e3946700-21d0-11eb-95cb-f5ef9cda4a22.png">

All `main` branch builds (which should be the live builds) will output the shortened commit hash, linked to commit on GitHub:

<img width="657" alt="Screen Shot 2020-11-08 at 14 44 58" src="https://user-images.githubusercontent.com/90316/98466638-fc9d1800-21d0-11eb-8cfe-84691d3ba5a1.png">
