### PR TITLE
markdown render fixes

### DIFF
--- a/src/components/atoms/Markdown.module.css
+++ b/src/components/atoms/Markdown.module.css
@@ -1,0 +1,71 @@
+.markdown {
+  /* handling long text, like URLs */
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+  word-break: break-word;
+}
+
+.markdown h1 {
+  font-size: var(--font-size-h3);
+}
+
+.markdown h2 {
+  font-size: var(--font-size-h4);
+}
+
+.markdown h3 {
+  font-size: var(--font-size-large);
+}
+
+.markdown h4,
+.markdown h5 {
+  font-size: var(--font-size-base);
+}
+
+.markdown ul,
+.markdown ol {
+  margin: 0;
+  margin-bottom: var(--spacer);
+  padding-left: 1.5rem;
+}
+
+.markdown ul {
+  list-style: none;
+}
+
+.markdown ul li {
+  position: relative;
+  display: block;
+}
+
+.markdown ul li:before {
+  content: '▪';
+  top: -2px;
+  position: absolute;
+  left: -1.5rem;
+  color: var(--brand-grey-light);
+  user-select: none;
+}
+
+.markdown li + li {
+  margin-top: calc(var(--spacer) / 8);
+}
+
+.markdown li ul,
+.markdown li ol,
+.markdown li p {
+  margin-bottom: 0;
+  margin-top: calc(var(--spacer) / 8);
+}
+
+.markdown hr {
+  display: block;
+  margin: calc(var(--spacer) * 1.5) auto;
+  max-width: 20%;
+  border: 0;
+  border-top: 2px solid var(--border-color);
+}
+
+.markdown img {
+  margin-bottom: calc(var(--spacer) / 2);
+}

--- a/src/components/atoms/Markdown.tsx
+++ b/src/components/atoms/Markdown.tsx
@@ -1,5 +1,6 @@
 import React, { ReactElement } from 'react'
 import ReactMarkdown from 'react-markdown'
+import styles from './Markdown.module.css'
 
 const Markdown = ({
   text,
@@ -12,7 +13,12 @@ const Markdown = ({
   // https://github.com/rexxars/react-markdown/issues/105#issuecomment-351585313
   const textCleaned = text.replace(/\\n/g, '\n ')
 
-  return <ReactMarkdown source={textCleaned} className={className} />
+  return (
+    <ReactMarkdown
+      source={textCleaned}
+      className={`${styles.markdown} ${className}`}
+    />
+  )
 }
 
 export default Markdown

--- a/src/components/organisms/AssetContent/index.module.css
+++ b/src/components/organisms/AssetContent/index.module.css
@@ -46,22 +46,3 @@
   margin-top: var(--spacer);
   margin-bottom: var(--spacer);
 }
-
-/* Markdown tweaks */
-
-.description h1 {
-  font-size: var(--font-size-h3);
-}
-
-.description h2 {
-  font-size: var(--font-size-h4);
-}
-
-.description h3 {
-  font-size: var(--font-size-large);
-}
-
-.description h4,
-.description h5 {
-  font-size: var(--font-size-base);
-}

--- a/src/components/pages/Publish/Preview.module.css
+++ b/src/components/pages/Publish/Preview.module.css
@@ -40,25 +40,6 @@
   margin-top: calc(var(--spacer) / 4);
 }
 
-/* Markdown tweaks */
-
-.description h1 {
-  font-size: var(--font-size-h3);
-}
-
-.description h2 {
-  font-size: var(--font-size-h4);
-}
-
-.description h3 {
-  font-size: var(--font-size-large);
-}
-
-.description h4,
-.description h5 {
-  font-size: var(--font-size-base);
-}
-
 .toggle {
   position: absolute;
   bottom: 0.15rem;


### PR DESCRIPTION
Most rendered markdown has reset styles, so port over what we use on `site` & `docs` so all rendered markdown in preview and on asset details description shows up properly.

E.g. with `hr` & `ul` usage, before:
<img width="708" alt="Screen Shot 2020-11-10 at 23 27 39" src="https://user-images.githubusercontent.com/90316/98741179-79381e00-23ac-11eb-82b4-9fc75f5703f0.png">

After:
<img width="709" alt="Screen Shot 2020-11-10 at 23 26 54" src="https://user-images.githubusercontent.com/90316/98741185-7d643b80-23ac-11eb-86db-f97112b84904.png">

<img width="1000" alt="Screen Shot 2020-11-11 at 00 00 52" src="https://user-images.githubusercontent.com/90316/98743850-ffeefa00-23b0-11eb-8d1b-177e049e4af2.png">
