### PR TITLE
quick update metadata page

### DIFF
--- a/src/pages/update.tsx
+++ b/src/pages/update.tsx
@@ -7,10 +7,11 @@ import { useOcean } from '@oceanprotocol/react'
 import Loader from '../components/atoms/Loader'
 import { DDO } from '@oceanprotocol/lib'
 import Alert from '../components/atoms/Alert'
+import styles from '../components/atoms/Box.module.css'
 
 const pageTitle = 'Update Data Set'
 const pageDescription =
-  'Interim solution for updating title & description of a data set until a proper editing flow is implemented. No validation, no checks. Make sure your DID is correct and you are connected with the account you published the to-be-edited data set.'
+  'Interim solution for updating title & description of a data set until a proper editing flow is implemented. No validation, no checks. Make sure your DID is correct and that you are connected with the account you used to published your data set.'
 
 export default function PageGatsbyUpdateAsset(props: PageProps): ReactElement {
   const { ocean, account } = useOcean()
@@ -54,8 +55,14 @@ export default function PageGatsbyUpdateAsset(props: PageProps): ReactElement {
 
   return (
     <Layout title={pageTitle} description={pageDescription} uri={props.uri}>
-      <form>
-        <Input name="did" label="DID" onChange={handleChangeDid} required />
+      <form className={styles.box}>
+        <Input
+          name="did"
+          label="DID"
+          placeholder="e.g. did:op:C1d97aEAb57622B2d139f10351B48CBf94071e5c"
+          onChange={handleChangeDid}
+          required
+        />
         <Input name="title" label="New Title" onChange={handleChangeTitle} />
         <Input
           type="textarea"
@@ -64,7 +71,11 @@ export default function PageGatsbyUpdateAsset(props: PageProps): ReactElement {
           onChange={handleChangeDescription}
           rows={4}
         />
-        <Button style="primary" onClick={handleSubmit}>
+        <Button
+          style="primary"
+          onClick={handleSubmit}
+          disabled={isLoading || !ocean || !account || !did}
+        >
           {isLoading ? <Loader /> : 'Submit'}
         </Button>
 

--- a/src/pages/update.tsx
+++ b/src/pages/update.tsx
@@ -1,5 +1,5 @@
 import React, { ChangeEvent, ReactElement, useState } from 'react'
-import Layout from '../components/Layout'
+import Page from '../components/templates/Page'
 import { PageProps } from 'gatsby'
 import Input from '../components/atoms/Input'
 import Button from '../components/atoms/Button'
@@ -54,7 +54,7 @@ export default function PageGatsbyUpdateAsset(props: PageProps): ReactElement {
   }
 
   return (
-    <Layout title={pageTitle} description={pageDescription} uri={props.uri}>
+    <Page title={pageTitle} description={pageDescription} uri={props.uri}>
       <form className={styles.box}>
         <Input
           name="did"
@@ -81,6 +81,6 @@ export default function PageGatsbyUpdateAsset(props: PageProps): ReactElement {
 
         {ddo?.id && <Alert state="success" text="Updated!" />}
       </form>
-    </Layout>
+    </Page>
   )
 }

--- a/src/pages/update.tsx
+++ b/src/pages/update.tsx
@@ -1,0 +1,75 @@
+import React, { ChangeEvent, ReactElement, useState } from 'react'
+import Layout from '../components/Layout'
+import { PageProps } from 'gatsby'
+import Input from '../components/atoms/Input'
+import Button from '../components/atoms/Button'
+import { useOcean } from '@oceanprotocol/react'
+import Loader from '../components/atoms/Loader'
+import { DDO } from '@oceanprotocol/lib'
+import Alert from '../components/atoms/Alert'
+
+const pageTitle = 'Update Data Set'
+const pageDescription =
+  'Interim solution for updating title & description of a data set until a proper editing flow is implemented. No validation, no checks. Make sure your DID is correct and you are connected with the account you published the to-be-edited data set.'
+
+export default function PageGatsbyUpdateAsset(props: PageProps): ReactElement {
+  const { ocean, account } = useOcean()
+  const [did, setDid] = useState<string>()
+  const [title, setTitle] = useState<string>()
+  const [description, setDescription] = useState<string>()
+  const [isLoading, setIsLoading] = useState<boolean>()
+  const [ddo, setDdo] = useState<DDO>()
+
+  async function handleSubmit(e: ChangeEvent<HTMLButtonElement>) {
+    e.preventDefault()
+
+    if (!did) return
+
+    try {
+      setIsLoading(true)
+      const ddo = await ocean.assets.editMetadata(
+        did,
+        { title, description },
+        account
+      )
+      setDdo(ddo)
+    } catch (error) {
+      console.error(error.message)
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  function handleChangeDid(e: ChangeEvent<HTMLInputElement>) {
+    setDid(e.target.value)
+  }
+
+  function handleChangeTitle(e: ChangeEvent<HTMLInputElement>) {
+    setTitle(e.target.value)
+  }
+
+  function handleChangeDescription(e: ChangeEvent<HTMLInputElement>) {
+    setDescription(e.target.value)
+  }
+
+  return (
+    <Layout title={pageTitle} description={pageDescription} uri={props.uri}>
+      <form>
+        <Input name="did" label="DID" onChange={handleChangeDid} required />
+        <Input name="title" label="New Title" onChange={handleChangeTitle} />
+        <Input
+          type="textarea"
+          name="description"
+          label="New Description"
+          onChange={handleChangeDescription}
+          rows={4}
+        />
+        <Button style="primary" onClick={handleSubmit}>
+          {isLoading ? <Loader /> : 'Submit'}
+        </Button>
+
+        {ddo?.id && <Alert state="success" text="Updated!" />}
+      </form>
+    </Layout>
+  )
+}


### PR DESCRIPTION
Interims solution for #237 with many missing checks and weird user flow on extra page `/update`. But we can use it to send to people and instruct them when need comes up, instead of doing it for them. Page is not linked anywhere to keep confusion low.

<img width="1246" alt="Screen Shot 2020-11-12 at 00 02 46" src="https://user-images.githubusercontent.com/90316/98874372-6db32880-247a-11eb-9672-c4cabf643655.png">

No further work should be put into this, it's supposed to only provide the bare essentials and we could even keep it only in this pull request:
https://market-git-feature-quick-metadata-update.oceanprotocol.vercel.app/update