### PR TITLE
hit Aquarius only when config is present

### DIFF
--- a/src/components/molecules/Bookmarks.tsx
+++ b/src/components/molecules/Bookmarks.tsx
@@ -67,7 +67,7 @@ export default function Bookmarks(): ReactElement {
   const [isLoading, setIsLoading] = useState<boolean>()
 
   useEffect(() => {
-    if (!config || bookmarks === {}) return
+    if (!config?.metadataCacheUri || bookmarks === {}) return
 
     const networkName = (config as ConfigHelperConfig).network
 

--- a/src/components/organisms/AssetActions/Pool/index.tsx
+++ b/src/components/organisms/AssetActions/Pool/index.tsx
@@ -203,7 +203,13 @@ export default function Pool({ ddo }: { ddo: DDO }): ReactElement {
 
   // Get graph history data
   useEffect(() => {
-    if (!price?.address || !price?.ocean || !price?.value) return
+    if (
+      !price?.address ||
+      !price?.ocean ||
+      !price?.value ||
+      !config?.metadataCacheUri
+    )
+      return
 
     const source = axios.CancelToken.source()
     const url = `${config.metadataCacheUri}/api/v1/aquarius/pools/history/${price.address}`

--- a/src/components/pages/History/PoolShares.tsx
+++ b/src/components/pages/History/PoolShares.tsx
@@ -67,7 +67,7 @@ export default function PoolShares(): ReactElement {
 
   useEffect(() => {
     async function getAssets() {
-      if (!ocean || !accountId) return
+      if (!ocean || !accountId || !config?.metadataCacheUri) return
       setIsLoading(true)
 
       try {

--- a/src/components/pages/Home.tsx
+++ b/src/components/pages/Home.tsx
@@ -112,6 +112,8 @@ export default function HomePage(): ReactElement {
   const [loading, setLoading] = useState(true)
 
   useEffect(() => {
+    if (!config?.metadataCacheUri) return
+
     // TODO: remove any once ocean.js has nativeSearch typings
     async function init() {
       const queryResultHighest = await getAssets(

--- a/src/components/templates/AssetDetails.tsx
+++ b/src/components/templates/AssetDetails.tsx
@@ -22,6 +22,8 @@ export default function PageTemplateAssetDetails({
   const [ddo, setDdo] = useState<DDO>()
 
   useEffect(() => {
+    if (!config?.metadataCacheUri) return
+
     async function init() {
       if (ddo) return
 

--- a/src/components/templates/Search/index.tsx
+++ b/src/components/templates/Search/index.tsx
@@ -20,6 +20,8 @@ export default function SearchPage({
   const [loading, setLoading] = useState<boolean>()
 
   useEffect(() => {
+    if (!config?.metadataCacheUri) return
+
     async function initSearch() {
       setLoading(true)
       const queryResult = await getResults(parsed, config.metadataCacheUri)


### PR DESCRIPTION
We are hitting this not found route a lot, I assume it is when users switch between networks where the `config.metadataCacheUri` is `undefined` for some milliseconds.

<img width="630" alt="Screen Shot 2020-11-17 at 13 15 28" src="https://user-images.githubusercontent.com/90316/99389207-f7c61b80-28d6-11eb-9751-175b42443157.png">

So prevent all Aquarius queries in effects when `config` or `config.metadataCacheUri` is not present