### PR TITLE
bump ocean.js & react hooks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3736,9 +3736,9 @@
       "integrity": "sha512-yoGk4kpTy9E06OWusd3Fa/W3yjmFNKND/I92YtmrMnX0i3gm/kom/Z7XrRiAHVC8JVnM9Q79FojGLd2eOL4opg=="
     },
     "@oceanprotocol/lib": {
-      "version": "0.9.21",
-      "resolved": "https://registry.npmjs.org/@oceanprotocol/lib/-/lib-0.9.21.tgz",
-      "integrity": "sha512-Bo+xJeFXOMfqof0GA5B07wWkBJ9S/v646zrUGuVIZ7nmwnGR8ba5Sr3lznpz7JIvmIpSNsKkXXWwwsRtZeeA1w==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@oceanprotocol/lib/-/lib-0.10.0.tgz",
+      "integrity": "sha512-ibsdyCS3ROUMShznaSvThHuTaGxKXCMedZfkvkFY1iFJvUL8HgJ0V6kRINNZDamj8AxLjEI1uV1QA3UTB8qkJA==",
       "requires": {
         "@ethereum-navigator/navigator": "^0.5.2",
         "@oceanprotocol/contracts": "^0.5.8",
@@ -3769,6 +3769,30 @@
         "decimal.js": "^10.2.1",
         "web3": "1.3.1",
         "web3modal": "^1.9.3"
+      },
+      "dependencies": {
+        "@oceanprotocol/lib": {
+          "version": "0.9.21",
+          "resolved": "https://registry.npmjs.org/@oceanprotocol/lib/-/lib-0.9.21.tgz",
+          "integrity": "sha512-Bo+xJeFXOMfqof0GA5B07wWkBJ9S/v646zrUGuVIZ7nmwnGR8ba5Sr3lznpz7JIvmIpSNsKkXXWwwsRtZeeA1w==",
+          "requires": {
+            "@ethereum-navigator/navigator": "^0.5.2",
+            "@oceanprotocol/contracts": "^0.5.8",
+            "decimal.js": "^10.2.1",
+            "fs": "0.0.1-security",
+            "lzma": "^2.3.2",
+            "node-fetch": "^2.6.1",
+            "save-file": "^2.3.1",
+            "uuid": "^8.3.2",
+            "web3": "^1.3.0",
+            "web3-eth-contract": "^1.3.0"
+          }
+        },
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+        }
       }
     },
     "@oceanprotocol/typographies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3760,39 +3760,15 @@
       }
     },
     "@oceanprotocol/react": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@oceanprotocol/react/-/react-0.4.1.tgz",
-      "integrity": "sha512-nPrmtv0nKLsXshxoOHN4ls2Cy7R3xchkqNJhNt5DPKGTj7YnMZvqa1UAoYB+5tqUNPC/irZc2+RsyHbyuhPqcg==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@oceanprotocol/react/-/react-0.5.0.tgz",
+      "integrity": "sha512-T+osx49SHebBC0j0HR62uXRhB2GoYnxHSbQiEdVxlLp/D4s0ey4GzNkVSNi0Dr4GuVZyactJuF3JfUbKhzuJZg==",
       "requires": {
-        "@oceanprotocol/lib": "^0.9.21",
+        "@oceanprotocol/lib": "^0.10.0",
         "axios": "^0.21.1",
         "decimal.js": "^10.2.1",
         "web3": "1.3.1",
         "web3modal": "^1.9.3"
-      },
-      "dependencies": {
-        "@oceanprotocol/lib": {
-          "version": "0.9.21",
-          "resolved": "https://registry.npmjs.org/@oceanprotocol/lib/-/lib-0.9.21.tgz",
-          "integrity": "sha512-Bo+xJeFXOMfqof0GA5B07wWkBJ9S/v646zrUGuVIZ7nmwnGR8ba5Sr3lznpz7JIvmIpSNsKkXXWwwsRtZeeA1w==",
-          "requires": {
-            "@ethereum-navigator/navigator": "^0.5.2",
-            "@oceanprotocol/contracts": "^0.5.8",
-            "decimal.js": "^10.2.1",
-            "fs": "0.0.1-security",
-            "lzma": "^2.3.2",
-            "node-fetch": "^2.6.1",
-            "save-file": "^2.3.1",
-            "uuid": "^8.3.2",
-            "web3": "^1.3.0",
-            "web3-eth-contract": "^1.3.0"
-          }
-        },
-        "uuid": {
-          "version": "8.3.2",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
-        }
       }
     },
     "@oceanprotocol/typographies": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@loadable/component": "^5.14.1",
     "@oceanprotocol/art": "^3.0.0",
     "@oceanprotocol/lib": "^0.10.0",
-    "@oceanprotocol/react": "^0.4.1",
+    "@oceanprotocol/react": "^0.5.0",
     "@oceanprotocol/typographies": "^0.1.0",
     "@sindresorhus/slugify": "^1.0.0",
     "@tippyjs/react": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@coingecko/cryptoformat": "^0.4.2",
     "@loadable/component": "^5.14.1",
     "@oceanprotocol/art": "^3.0.0",
-    "@oceanprotocol/lib": "^0.9.21",
+    "@oceanprotocol/lib": "^0.10.0",
     "@oceanprotocol/react": "^0.4.1",
     "@oceanprotocol/typographies": "^0.1.0",
     "@sindresorhus/slugify": "^1.0.0",

--- a/src/components/organisms/AssetActions/Edit/index.tsx
+++ b/src/components/organisms/AssetActions/Edit/index.tsx
@@ -55,7 +55,7 @@ export default function Edit({
   const content = data.content.edges[0].node.childPagesJson
 
   const { debug } = useUserPreferences()
-  const { ocean } = useOcean()
+  const { ocean, accountId } = useOcean()
   const { metadata, ddo, refreshDdo } = useAsset()
   const [success, setSuccess] = useState<string>()
   const [error, setError] = useState<string>()
@@ -67,13 +67,17 @@ export default function Edit({
     resetForm: () => void
   ) {
     try {
+      // Construct new DDO with new values
       const newDdo = await ocean.assets.editMetadata(ddo, {
         title: values.name,
         description: values.description
       })
 
+      // Update DDO on-chain
+      const tx = await ocean.assets.updateMetadata(newDdo, accountId)
+
       // Edit failed
-      if (!newDdo) {
+      if (!newDdo || !tx) {
         setError(content.form.error)
         Logger.error(content.form.error)
         return

--- a/src/components/organisms/AssetActions/Edit/index.tsx
+++ b/src/components/organisms/AssetActions/Edit/index.tsx
@@ -55,8 +55,8 @@ export default function Edit({
   const content = data.content.edges[0].node.childPagesJson
 
   const { debug } = useUserPreferences()
-  const { ocean, account } = useOcean()
-  const { did, metadata, ddo, refreshDdo } = useAsset()
+  const { ocean } = useOcean()
+  const { metadata, ddo, refreshDdo } = useAsset()
   const [success, setSuccess] = useState<string>()
   const [error, setError] = useState<string>()
 
@@ -67,14 +67,13 @@ export default function Edit({
     resetForm: () => void
   ) {
     try {
-      const ddo = await ocean.assets.editMetadata(
-        did,
-        { title: values.name, description: values.description },
-        account
-      )
+      const newDdo = await ocean.assets.editMetadata(ddo, {
+        title: values.name,
+        description: values.description
+      })
 
       // Edit failed
-      if (!ddo) {
+      if (!newDdo) {
         setError(content.form.error)
         Logger.error(content.form.error)
         return

--- a/src/components/pages/History/ComputeJobs.tsx
+++ b/src/components/pages/History/ComputeJobs.tsx
@@ -75,7 +75,7 @@ export default function ComputeJobs(): ReactElement {
 
   useEffect(() => {
     async function getTitle(did: string) {
-      const ddo = await ocean.metadatacache.retrieveDDO(did)
+      const ddo = await ocean.metadataCache.retrieveDDO(did)
       const metadata = ddo.findServiceByType('metadata')
       return metadata.attributes.main.name
     }


### PR DESCRIPTION
bump to ocean.js `v0.10.0` with breaking change to `ocean.assets.editMetadata`, and react hooks to `v0.5.0`. Requirement to make https://github.com/oceanprotocol/market/pull/324 work.