### PR TITLE
fix search navigation on localhost

### DIFF
--- a/src/components/molecules/SearchBar.tsx
+++ b/src/components/molecules/SearchBar.tsx
@@ -1,5 +1,5 @@
 import React, { useState, ChangeEvent, FormEvent, ReactElement } from 'react'
-import { useNavigate } from '@reach/router'
+import { navigate } from 'gatsby'
 import styles from './SearchBar.module.css'
 import Button from '../atoms/Button'
 import Input from '../atoms/Input'
@@ -17,7 +17,6 @@ export default function SearchBar({
   filters?: boolean
   size?: 'small' | 'large'
 }): ReactElement {
-  const navigate = useNavigate()
   const [value, setValue] = useState(initialValue || '')
 
   function handleChange(e: ChangeEvent<HTMLInputElement>) {

--- a/src/components/organisms/AssetQueryList.tsx
+++ b/src/components/organisms/AssetQueryList.tsx
@@ -1,7 +1,8 @@
 import AssetTeaser from '../molecules/AssetTeaser'
 import React from 'react'
 import { QueryResult } from '@oceanprotocol/lib/dist/node/metadatacache/MetadataCache'
-import { useLocation, useNavigate } from '@reach/router'
+import { useLocation } from '@reach/router'
+import { navigate } from 'gatsby'
 import Pagination from '../molecules/Pagination'
 import { updateQueryStringParameter } from '../../utils'
 import styles from './AssetQueryList.module.css'
@@ -20,7 +21,6 @@ const AssetQueryList: React.FC<AssetQueryListProps> = ({
   className
 }) => {
   const location = useLocation()
-  const navigate = useNavigate()
 
   // Construct the urls on the pagination links. This is only for UX,
   // since the links are no <Link> they will not work by itself.


### PR DESCRIPTION
On localhost when you search the url is broken, we used the wrong `navigate`
Fixes #347