### PR TITLE
Default contentLenght value

### DIFF
--- a/src/utils/provider.ts
+++ b/src/utils/provider.ts
@@ -28,7 +28,7 @@ export async function fileinfo(
     const { contentLength, contentType } = response.data[0]
 
     return {
-      contentLength,
+      contentLength: contentLength || '',
       contentType: contentType || '', // need to do that cause lib-js File interface requires contentType
       url
     }


### PR DESCRIPTION
Fixes #367.

Changes proposed in this PR:

- sets default value for contentLength if not received from the provider when hitting fileinfo