### PR TITLE
switch IPFS gateway

### DIFF
--- a/src/utils/profile.ts
+++ b/src/utils/profile.ts
@@ -5,7 +5,7 @@ import { Logger } from '@oceanprotocol/lib'
 
 // https://docs.3box.io/api/rest-api
 const apiUri = 'https://3box.oceanprotocol.com'
-const ipfsUrl = 'https://ipfs.oceanprotocol.com'
+const ipfsUrl = 'https://dweb.link'
 
 function decodeProof(proofJWT: string) {
   if (!proofJWT) return


### PR DESCRIPTION
* switch to dweb.link for loading 3Box profile images
* ipfs.oceanprotocol.com has been deprecated

Proof of it's Working:

<img width="869" alt="Screen Shot 2021-02-25 at 14 55 40" src="https://user-images.githubusercontent.com/90316/109163382-92a58000-7779-11eb-8a97-222da16b2680.png">
