### PR TITLE
Validate custom Docker images

### DIFF
--- a/src/components/molecules/MetadataPreview.tsx
+++ b/src/components/molecules/MetadataPreview.tsx
@@ -157,7 +157,11 @@ export function MetadataAlgorithmPreview({
           />
         )}
         {values.algorithmPrivacy && (
-          <MetaItem key="dockerImage" title="Private Algorithm" content="Yes" />
+          <MetaItem
+            key="algorithmPreview"
+            title="Private Algorithm"
+            content="Yes"
+          />
         )}
       </div>
       <MetaFull values={values} />

--- a/src/components/pages/Publish/FormAlgoPublish.tsx
+++ b/src/components/pages/Publish/FormAlgoPublish.tsx
@@ -134,7 +134,6 @@ export default function FormPublish(): ReactElement {
             <Field
               key={field.name}
               {...field}
-              disabled={field.disabled}
               component={Input}
               onChange={(e: ChangeEvent<HTMLInputElement>) =>
                 handleFieldChange(e, field)

--- a/src/components/pages/Publish/index.tsx
+++ b/src/components/pages/Publish/index.tsx
@@ -11,11 +11,11 @@ import {
   initialValues as initialValuesAlgorithm,
   validationSchema as validationSchemaAlgorithm
 } from '../../../models/FormAlgoPublish'
-
 import {
   transformPublishFormToMetadata,
   transformPublishAlgorithmFormToMetadata,
-  mapTimeoutStringToSeconds
+  mapTimeoutStringToSeconds,
+  validateDockerImage
 } from '../../../utils/metadata'
 import {
   MetadataPreview,
@@ -156,9 +156,13 @@ export default function PublishPage({
     ) => void
   ): Promise<void> {
     const metadata = transformPublishAlgorithmFormToMetadata(values)
-
     try {
       Logger.log('Publish Algorithm with ', metadata)
+
+      const validImage = await validateDockerImage(
+        values.image,
+        values.containerTag
+      )
 
       const ddo = await publish(
         (metadata as unknown) as Metadata,

--- a/src/utils/metadata.ts
+++ b/src/utils/metadata.ts
@@ -1,5 +1,6 @@
 import axios, { CancelToken, AxiosResponse } from 'axios'
 import { toast } from 'react-toastify'
+import isUrl from 'is-url-superb'
 import {
   MetadataMarket,
   MetadataPublishFormDataset,
@@ -157,7 +158,7 @@ async function isDockerHubImageValid(
 
 async function is3rdPartyImageValid(imageURL: string): Promise<boolean> {
   try {
-    const response = await axios.options(imageURL)
+    const response = await axios.head(imageURL)
     if (!response || response.status !== 200) {
       toast.error(
         'Could not fetch docker image info. Please check URL and try again'
@@ -172,19 +173,6 @@ async function is3rdPartyImageValid(imageURL: string): Promise<boolean> {
     )
     return false
   }
-}
-
-function isUrl(image: string): boolean {
-  const pattern = new RegExp(
-    '^(https?:\\/\\/)?' +
-      '((([a-z\\d]([a-z\\d-]*[a-z\\d])*)\\.)+[a-z]{2,}|' +
-      '((\\d{1,3}\\.){3}\\d{1,3}))' +
-      '(\\:\\d+)?(\\/[-a-z\\d%_.~+]*)*' +
-      '(\\?[;&a-z\\d%_.~+=-]*)?' +
-      '(\\#[-a-z\\d_]*)?$',
-    'i'
-  )
-  return !!pattern.test(image)
 }
 
 export async function validateDockerImage(

--- a/src/utils/metadata.ts
+++ b/src/utils/metadata.ts
@@ -148,6 +148,9 @@ async function isDockerHubImageValid(
     return true
   } catch (error) {
     Logger.error(error.message)
+    toast.error(
+      'Could not fetch docker hub image info. Please check image name and tag and try again'
+    )
     return false
   }
 }
@@ -164,6 +167,9 @@ async function is3rdPartyImageValid(imageURL: string): Promise<boolean> {
     return true
   } catch (error) {
     Logger.error(error.message)
+    toast.error(
+      'Could not fetch docker image info. Please check URL and try again'
+    )
     return false
   }
 }


### PR DESCRIPTION
Fixes #398 .

Changes proposed in this PR:

- validate docker hub images ( the get req to the docker hub is blocked by CORS when running locally)
- validate 3rd party images (just a options request to the provided url and checked response status)
