### PR TITLE
Fix/ Search query with price filter and no text

### DIFF
--- a/src/components/templates/Search/utils.ts
+++ b/src/components/templates/Search/utils.ts
@@ -33,9 +33,9 @@ type FilterByPriceOptions = typeof FilterByPriceOptions[keyof typeof FilterByPri
 
 function addPriceFilterToQuerry(sortTerm: string, priceFilter: string): string {
   sortTerm = priceFilter
-    ? sortTerm === ''
-      ? `price.type:${priceFilter}`
-      : `${sortTerm} AND price.type:${priceFilter}`
+    ? /\S/.test(sortTerm)
+      ? `${sortTerm} AND price.type:${priceFilter}`
+      : `price.type:${priceFilter}`
     : sortTerm
   return sortTerm
 }


### PR DESCRIPTION
Fixes #407  .

Changes proposed in this PR:

- fixes search when price filter applied and text is empty or contains only whitespaces