### PR TITLE
more fine grained price issues display

### DIFF
--- a/src/components/atoms/Price/index.tsx
+++ b/src/components/atoms/Price/index.tsx
@@ -28,10 +28,15 @@ export default function Price({
       conversion={conversion}
       type={price.type}
     />
-  ) : !price || price?.value === 0 ? (
+  ) : !price || !price.address ? (
     <div className={styles.empty}>
-      No price found{' '}
+      No price set{' '}
       <Tooltip content="We could not find a pool for this data set, which can have multiple reasons. Is your wallet connected to the correct network?" />
+    </div>
+  ) : price.isConsumable !== 'true' ? (
+    <div className={styles.empty}>
+      Not enough liquidity{' '}
+      <Tooltip content="This pool does not have enough liquidity for using thisa data set." />
     </div>
   ) : (
     <Loader message="Retrieving price..." />

--- a/src/components/atoms/Price/index.tsx
+++ b/src/components/atoms/Price/index.tsx
@@ -28,10 +28,10 @@ export default function Price({
       conversion={conversion}
       type={price.type}
     />
-  ) : !price || !price.address ? (
+  ) : !price || !price.address || price.address === '' ? (
     <div className={styles.empty}>
       No price set{' '}
-      <Tooltip content="We could not find a pool for this data set, which can have multiple reasons. Is your wallet connected to the correct network?" />
+      <Tooltip content="No pricing mechanism has been set yet on this asset." />
     </div>
   ) : price.isConsumable !== 'true' ? (
     <div className={styles.empty}>

--- a/src/components/atoms/Price/index.tsx
+++ b/src/components/atoms/Price/index.tsx
@@ -31,12 +31,12 @@ export default function Price({
   ) : !price || !price.address || price.address === '' ? (
     <div className={styles.empty}>
       No price set{' '}
-      <Tooltip content="No pricing mechanism has been set yet on this asset." />
+      <Tooltip content="No pricing mechanism has been set on this asset yet." />
     </div>
   ) : price.isConsumable !== 'true' ? (
     <div className={styles.empty}>
-      Not enough liquidity{' '}
-      <Tooltip content="This pool does not have enough liquidity for using thisa data set." />
+      Low liquidity{' '}
+      <Tooltip content="This pool does not have enough liquidity for using this data set." />
     </div>
   ) : (
     <Loader message="Retrieving price..." />

--- a/src/components/organisms/AssetActions/Consume.tsx
+++ b/src/components/organisms/AssetActions/Consume.tsx
@@ -158,13 +158,7 @@ export default function Consume({
           <File file={file} />
         </div>
         <div className={styles.pricewrapper}>
-          {isConsumable ? (
-            <Price ddo={ddo} conversion />
-          ) : (
-            <div className={styles.help}>
-              There is not enough liquidity in the pool to buy this data set.
-            </div>
-          )}
+          <Price ddo={ddo} conversion />
           {!isInPurgatory && <PurchaseButton />}
         </div>
       </div>


### PR DESCRIPTION
closes https://github.com/oceanprotocol/market/issues/415

Changes proposed in this PR:
- differentiate between no price set (no `price.address`), and low liquidity (no `price.isConsumable`)
- centralize all checks in `Price` component

<img width="391" alt="Screen Shot 2021-03-01 at 16 11 29" src="https://user-images.githubusercontent.com/90316/109516736-d0bbe000-7aa8-11eb-974c-98cabce64801.png">

<img width="500" alt="Screen Shot 2021-03-01 at 16 11 49" src="https://user-images.githubusercontent.com/90316/109516753-d5809400-7aa8-11eb-8721-2c2edbf93e7b.png">


<img width="389" alt="Screen Shot 2021-03-01 at 16 14 54" src="https://user-images.githubusercontent.com/90316/109517182-458f1a00-7aa9-11eb-93b8-d54fa37bbc3d.png">

<img width="463" alt="Screen Shot 2021-03-01 at 16 15 21" src="https://user-images.githubusercontent.com/90316/109517244-55a6f980-7aa9-11eb-8c56-a5443349497d.png">
