### PR TITLE
refactor network name output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,5 @@ public/storybook
 .artifacts
 .vercel
 repo-metadata.json
+networks-metadata.json
 src/@types/apollo

--- a/app.config.js
+++ b/app.config.js
@@ -4,11 +4,17 @@ module.exports = {
   // networks in their wallet.
   // Ocean Protocol contracts are deployed for: 'mainnet', 'rinkeby', 'development'
   network: process.env.GATSBY_NETWORK || 'mainnet',
+
+  // List of supported networkId the market works with. Used for showing UI hints.
+  supportedNetworks: [1, 3, 4, 137, 80001],
+
   infuraProjectId: process.env.GATSBY_INFURA_PROJECT_ID || 'xxx',
+
   // The ETH address the marketplace fee will be sent to.
   marketFeeAddress:
     process.env.GATSBY_MARKET_FEE_ADDRESS ||
     '0x903322C7E45A60d7c8C3EA236c5beA9Af86310c7',
+
   // Used for conversion display, can be whatever coingecko API supports
   // see: https://api.coingecko.com/api/v3/simple/supported_vs_currencies
   currencies: [

--- a/app.config.js
+++ b/app.config.js
@@ -5,9 +5,6 @@ module.exports = {
   // Ocean Protocol contracts are deployed for: 'mainnet', 'rinkeby', 'development'
   network: process.env.GATSBY_NETWORK || 'mainnet',
 
-  // List of supported networkId the market works with. Used for showing UI hints.
-  supportedNetworks: [1, 3, 4, 137, 80001],
-
   infuraProjectId: process.env.GATSBY_INFURA_PROJECT_ID || 'xxx',
 
   // The ETH address the marketplace fee will be sent to.

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -11,6 +11,14 @@ execSync(`node ./scripts/write-repo-metadata > repo-metadata.json`, {
 // Generate Apollo typings
 execSync(`npm run apollo:codegen`, { stdio: 'inherit' })
 
+// Fetch EVM networks metadata
+execSync(
+  `node ./scripts/write-networks-metadata > content/networks-metadata.json`,
+  {
+    stdio: 'inherit'
+  }
+)
+
 exports.onCreateNode = ({ node, actions, getNode }) => {
   createFields(node, actions, getNode)
 }

--- a/scripts/write-networks-metadata.js
+++ b/scripts/write-networks-metadata.js
@@ -1,0 +1,11 @@
+#!/usr/bin/env node
+'use strict'
+
+const axios = require('axios')
+
+// https://github.com/ethereum-lists/chains
+const chainDataUrl = 'https://chainid.network/chains.json'
+
+axios(chainDataUrl).then((response) => {
+  process.stdout.write(JSON.stringify(response.data, null, '  '))
+})

--- a/src/components/atoms/EtherscanLink.tsx
+++ b/src/components/atoms/EtherscanLink.tsx
@@ -22,7 +22,7 @@ export default function EtherscanLink({
 
     async function init() {
       const network = await getNetworkData(networkId, source.token)
-      setNetwork(network.network)
+      setNetwork(network.data.network)
     }
     init()
 

--- a/src/components/molecules/Wallet/Account.module.css
+++ b/src/components/molecules/Wallet/Account.module.css
@@ -12,6 +12,7 @@
   transition: border 0.2s ease-out;
   cursor: pointer;
   min-width: 190px;
+  height: 100%;
 }
 
 .button,
@@ -42,7 +43,7 @@
 .address {
   text-transform: none;
   border-right: 1px solid var(--border-color);
-  padding-right: calc(var(--spacer) / 4);
+  padding-right: calc(var(--spacer) / 3);
 }
 
 .button svg {
@@ -51,7 +52,7 @@
   fill: var(--border-color);
   display: inline-block;
   vertical-align: middle;
-  margin-left: calc(var(--spacer) / 4);
+  margin-left: calc(var(--spacer) / 3);
   transition: transform 0.2s ease-out;
 }
 

--- a/src/components/molecules/Wallet/Account.tsx
+++ b/src/components/molecules/Wallet/Account.tsx
@@ -24,8 +24,8 @@ const Blockies = ({ account }: { account: string | undefined }) => {
 // Forward ref for Tippy.js
 // eslint-disable-next-line
 const Account = React.forwardRef((props, ref: any) => {
-  const { accountId, status, connect, networkId, web3Modal } = useOcean()
-  const hasSuccess = status === 1 && networkId === 1
+  const { accountId, status, connect, web3Modal } = useOcean()
+  const hasSuccess = status === 1
 
   async function handleActivation(e: FormEvent<HTMLButtonElement>) {
     // prevent accidentially submitting a form the button might be in

--- a/src/components/molecules/Wallet/Feedback.tsx
+++ b/src/components/molecules/Wallet/Feedback.tsx
@@ -2,7 +2,6 @@ import React, { ReactElement } from 'react'
 import Status from '../../atoms/Status'
 import styles from './Feedback.module.css'
 import { useOcean } from '@oceanprotocol/react'
-import { getNetworkName } from '../../../utils/wallet'
 
 export declare type Web3Error = {
   status: 'error' | 'warning' | 'success'
@@ -15,19 +14,13 @@ export default function Web3Feedback({
 }: {
   isBalanceSufficient?: boolean
 }): ReactElement {
-  const { account, status, networkId } = useOcean()
+  const { account, status } = useOcean()
   const isOceanConnectionError = status === -1
-  const isMainnet = networkId === 1
   const showFeedback =
-    !account ||
-    isOceanConnectionError ||
-    !isMainnet ||
-    isBalanceSufficient === false
+    !account || isOceanConnectionError || isBalanceSufficient === false
 
   const state = !account
     ? 'error'
-    : !isMainnet
-    ? 'warning'
     : account && isBalanceSufficient
     ? 'success'
     : 'warning'
@@ -36,8 +29,6 @@ export default function Web3Feedback({
     ? 'No account connected'
     : isOceanConnectionError
     ? 'Error connecting to Ocean'
-    : !isMainnet
-    ? getNetworkName(networkId)
     : account
     ? isBalanceSufficient === false
       ? 'Insufficient balance'
@@ -48,8 +39,6 @@ export default function Web3Feedback({
     ? 'Please connect your Web3 wallet.'
     : isOceanConnectionError
     ? 'Please try again.'
-    : !isMainnet
-    ? undefined
     : isBalanceSufficient === false
     ? 'You do not have enough OCEAN in your wallet to purchase this asset.'
     : 'Something went wrong.'

--- a/src/components/molecules/Wallet/Network.module.css
+++ b/src/components/molecules/Wallet/Network.module.css
@@ -21,3 +21,7 @@
   background-color: var(--border-color);
   color: var(--font-color-text);
 }
+
+.warning {
+  margin-right: calc(var(--spacer) / 4);
+}

--- a/src/components/molecules/Wallet/Network.module.css
+++ b/src/components/molecules/Wallet/Network.module.css
@@ -13,4 +13,5 @@
   font-size: var(--font-size-small);
   margin-left: calc(var(--spacer) / 8);
   display: inline-block;
+  text-transform: capitalize;
 }

--- a/src/components/molecules/Wallet/Network.module.css
+++ b/src/components/molecules/Wallet/Network.module.css
@@ -1,0 +1,16 @@
+.network {
+  border: 1px solid var(--border-color);
+  border-right: none;
+  border-top-left-radius: var(--border-radius);
+  border-bottom-left-radius: var(--border-radius);
+  padding: calc(var(--spacer) / 4) calc(var(--spacer) / 2);
+  white-space: nowrap;
+  color: var(--color-secondary);
+  margin-right: -3px;
+}
+
+.name {
+  font-size: var(--font-size-small);
+  margin-left: calc(var(--spacer) / 8);
+  display: inline-block;
+}

--- a/src/components/molecules/Wallet/Network.module.css
+++ b/src/components/molecules/Wallet/Network.module.css
@@ -5,13 +5,19 @@
   border-bottom-left-radius: var(--border-radius);
   padding: calc(var(--spacer) / 4) calc(var(--spacer) / 2);
   white-space: nowrap;
-  color: var(--color-secondary);
   margin-right: -3px;
+  display: inline-flex;
+  align-items: center;
 }
 
 .name {
   font-size: var(--font-size-small);
-  margin-left: calc(var(--spacer) / 8);
   display: inline-block;
   text-transform: capitalize;
+}
+
+.badge {
+  margin-left: calc(var(--spacer) / 8);
+  background-color: var(--border-color);
+  color: var(--font-color-text);
 }

--- a/src/components/molecules/Wallet/Network.tsx
+++ b/src/components/molecules/Wallet/Network.tsx
@@ -1,19 +1,23 @@
 import React, { useState, useEffect, ReactElement } from 'react'
 import { useOcean } from '@oceanprotocol/react'
-// import Status from '../../atoms/Status'
+import Status from '../../atoms/Status'
 import { getNetworkData } from '../../../utils/wallet'
 import { ConfigHelperConfig } from '@oceanprotocol/lib/dist/node/utils/ConfigHelper'
 import styles from './Network.module.css'
 import axios from 'axios'
 import Badge from '../../atoms/Badge'
+import { useSiteMetadata } from '../../../hooks/useSiteMetadata'
+import Tooltip from '../../atoms/Tooltip'
 
 export default function Network(): ReactElement {
+  const { appConfig } = useSiteMetadata()
   const { config, networkId } = useOcean()
   const networkIdConfig = (config as ConfigHelperConfig).networkId
 
   const [isMainnet, setIsMainnet] = useState<boolean>()
   const [networkName, setNetworkName] = useState<string>()
   const [isTestnet, setIsTestnet] = useState<boolean>()
+  const [isSupportedNetwork, setIsSupportedNetwork] = useState<boolean>()
 
   useEffect(() => {
     let isMounted = true
@@ -35,15 +39,22 @@ export default function Network(): ReactElement {
     }
     getName()
 
+    const isSupportedNetwork = appConfig.supportedNetworks.includes(network)
+    setIsSupportedNetwork(isSupportedNetwork)
+
     return () => {
       isMounted = false
       source.cancel()
     }
-  }, [networkId, networkIdConfig])
+  }, [networkId, networkIdConfig, appConfig.supportedNetworks])
 
-  return !isMainnet ? (
+  return !isMainnet && networkName ? (
     <div className={styles.network}>
-      {/* <Status state="warning" aria-hidden /> */}
+      {!isSupportedNetwork && (
+        <Tooltip content="No Ocean Protocol contracts are deployed to this network.">
+          <Status state="error" className={styles.warning} />
+        </Tooltip>
+      )}
       <span className={styles.name}>{networkName}</span>
       {isTestnet && <Badge label="Test" className={styles.badge} />}
     </div>

--- a/src/components/molecules/Wallet/Network.tsx
+++ b/src/components/molecules/Wallet/Network.tsx
@@ -2,15 +2,14 @@ import React, { useState, useEffect, ReactElement } from 'react'
 import { useOcean } from '@oceanprotocol/react'
 import Status from '../../atoms/Status'
 import { getNetworkData } from '../../../utils/wallet'
+import { ConfigHelper } from '@oceanprotocol/lib'
 import { ConfigHelperConfig } from '@oceanprotocol/lib/dist/node/utils/ConfigHelper'
 import styles from './Network.module.css'
 import axios from 'axios'
 import Badge from '../../atoms/Badge'
-import { useSiteMetadata } from '../../../hooks/useSiteMetadata'
 import Tooltip from '../../atoms/Tooltip'
 
 export default function Network(): ReactElement {
-  const { appConfig } = useSiteMetadata()
   const { config, networkId } = useOcean()
   const networkIdConfig = (config as ConfigHelperConfig).networkId
 
@@ -29,6 +28,11 @@ export default function Network(): ReactElement {
     const isMainnet = network === 1
     setIsMainnet(isMainnet)
 
+    // Check networkId against ocean.js ConfigHelper configs
+    // to figure out if network is supported.
+    const isSupportedNetwork = Boolean(new ConfigHelper().getConfig(network))
+    setIsSupportedNetwork(isSupportedNetwork)
+
     async function getName() {
       const networkData = await getNetworkData(network, source.token)
 
@@ -39,14 +43,11 @@ export default function Network(): ReactElement {
     }
     getName()
 
-    const isSupportedNetwork = appConfig.supportedNetworks.includes(network)
-    setIsSupportedNetwork(isSupportedNetwork)
-
     return () => {
       isMounted = false
       source.cancel()
     }
-  }, [networkId, networkIdConfig, appConfig.supportedNetworks])
+  }, [networkId, networkIdConfig])
 
   return !isMainnet && networkName ? (
     <div className={styles.network}>

--- a/src/components/molecules/Wallet/Network.tsx
+++ b/src/components/molecules/Wallet/Network.tsx
@@ -1,0 +1,28 @@
+import React, { useState, useEffect, ReactElement } from 'react'
+import { useOcean } from '@oceanprotocol/react'
+import Status from '../../atoms/Status'
+import { getNetworkName } from '../../../utils/wallet'
+import { ConfigHelperConfig } from '@oceanprotocol/lib/dist/node/utils/ConfigHelper'
+import styles from './Network.module.css'
+
+export default function Network(): ReactElement {
+  const { config, networkId } = useOcean()
+  const [networkToShow, setNetworkToShow] = useState<number>()
+  const [isMainnet, setIsMainnet] = useState<boolean>()
+
+  useEffect(() => {
+    // take network from user when present, otherwise the default configured one of app
+    const networktoShow = networkId || (config as ConfigHelperConfig).networkId
+    setNetworkToShow(networktoShow)
+
+    const isMainnet = networktoShow === 1
+    setIsMainnet(isMainnet)
+  }, [networkId, config])
+
+  return !isMainnet && networkToShow ? (
+    <div className={styles.network}>
+      <Status state="warning" aria-hidden />
+      <span className={styles.name}>{getNetworkName(networkToShow)}</span>
+    </div>
+  ) : null
+}

--- a/src/components/molecules/Wallet/Network.tsx
+++ b/src/components/molecules/Wallet/Network.tsx
@@ -1,10 +1,11 @@
 import React, { useState, useEffect, ReactElement } from 'react'
 import { useOcean } from '@oceanprotocol/react'
-import Status from '../../atoms/Status'
-import { getNetworkDisplayName } from '../../../utils/wallet'
+// import Status from '../../atoms/Status'
+import { getNetworkData } from '../../../utils/wallet'
 import { ConfigHelperConfig } from '@oceanprotocol/lib/dist/node/utils/ConfigHelper'
 import styles from './Network.module.css'
 import axios from 'axios'
+import Badge from '../../atoms/Badge'
 
 export default function Network(): ReactElement {
   const { config, networkId } = useOcean()
@@ -12,19 +13,25 @@ export default function Network(): ReactElement {
 
   const [isMainnet, setIsMainnet] = useState<boolean>()
   const [networkName, setNetworkName] = useState<string>()
+  const [isTestnet, setIsTestnet] = useState<boolean>()
 
   useEffect(() => {
     let isMounted = true
     const source = axios.CancelToken.source()
 
-    // take network from user when present, otherwise the default configured one of app
+    // take network from user when present,
+    // otherwise use the default configured one of app
     const network = networkId || networkIdConfig
     const isMainnet = network === 1
     setIsMainnet(isMainnet)
 
     async function getName() {
-      const networkName = await getNetworkDisplayName(network, source.token)
-      isMounted && setNetworkName(networkName)
+      const networkData = await getNetworkData(network, source.token)
+
+      if (isMounted) {
+        setIsTestnet(networkData.data.network !== 'mainnet')
+        setNetworkName(networkData.displayName)
+      }
     }
     getName()
 
@@ -36,8 +43,9 @@ export default function Network(): ReactElement {
 
   return !isMainnet ? (
     <div className={styles.network}>
-      <Status state="warning" aria-hidden />
+      {/* <Status state="warning" aria-hidden /> */}
       <span className={styles.name}>{networkName}</span>
+      {isTestnet && <Badge label="Test" className={styles.badge} />}
     </div>
   ) : null
 }

--- a/src/components/molecules/Wallet/Network.tsx
+++ b/src/components/molecules/Wallet/Network.tsx
@@ -35,7 +35,7 @@ export default function Network(): ReactElement {
   const { config, networkId } = useOcean()
   const networkIdConfig = (config as ConfigHelperConfig).networkId
 
-  const [isMainnet, setIsMainnet] = useState<boolean>()
+  const [isEthMainnet, setIsEthMainnet] = useState<boolean>()
   const [networkName, setNetworkName] = useState<string>()
   const [isTestnet, setIsTestnet] = useState<boolean>()
   const [isSupportedNetwork, setIsSupportedNetwork] = useState<boolean>()
@@ -44,8 +44,8 @@ export default function Network(): ReactElement {
     // take network from user when present,
     // otherwise use the default configured one of app
     const network = networkId || networkIdConfig
-    const isMainnet = network === 1
-    setIsMainnet(isMainnet)
+    const isEthMainnet = network === 1
+    setIsEthMainnet(isEthMainnet)
 
     // Check networkId against ocean.js ConfigHelper configs
     // to figure out if network is supported.
@@ -60,7 +60,7 @@ export default function Network(): ReactElement {
     setNetworkName(networkName)
   }, [networkId, networkIdConfig, networksList])
 
-  return !isMainnet && networkName ? (
+  return !isEthMainnet && networkName ? (
     <div className={styles.network}>
       {!isSupportedNetwork && (
         <Tooltip content="No Ocean Protocol contracts are deployed to this network.">

--- a/src/components/molecules/Wallet/Network.tsx
+++ b/src/components/molecules/Wallet/Network.tsx
@@ -1,28 +1,43 @@
 import React, { useState, useEffect, ReactElement } from 'react'
 import { useOcean } from '@oceanprotocol/react'
 import Status from '../../atoms/Status'
-import { getNetworkName } from '../../../utils/wallet'
+import { getNetworkDisplayName } from '../../../utils/wallet'
 import { ConfigHelperConfig } from '@oceanprotocol/lib/dist/node/utils/ConfigHelper'
 import styles from './Network.module.css'
+import axios from 'axios'
 
 export default function Network(): ReactElement {
   const { config, networkId } = useOcean()
-  const [networkToShow, setNetworkToShow] = useState<number>()
+  const networkIdConfig = (config as ConfigHelperConfig).networkId
+
   const [isMainnet, setIsMainnet] = useState<boolean>()
+  const [networkName, setNetworkName] = useState<string>()
 
   useEffect(() => {
+    let isMounted = true
+    const source = axios.CancelToken.source()
+
     // take network from user when present, otherwise the default configured one of app
-    const networktoShow = networkId || (config as ConfigHelperConfig).networkId
-    setNetworkToShow(networktoShow)
-
-    const isMainnet = networktoShow === 1
+    const network = networkId || networkIdConfig
+    const isMainnet = network === 1
     setIsMainnet(isMainnet)
-  }, [networkId, config])
 
-  return !isMainnet && networkToShow ? (
+    async function getName() {
+      const networkName = await getNetworkDisplayName(network, source.token)
+      isMounted && setNetworkName(networkName)
+    }
+    getName()
+
+    return () => {
+      isMounted = false
+      source.cancel()
+    }
+  }, [networkId, networkIdConfig])
+
+  return !isMainnet ? (
     <div className={styles.network}>
       <Status state="warning" aria-hidden />
-      <span className={styles.name}>{getNetworkName(networkToShow)}</span>
+      <span className={styles.name}>{networkName}</span>
     </div>
   ) : null
 }

--- a/src/components/molecules/Wallet/index.module.css
+++ b/src/components/molecules/Wallet/index.module.css
@@ -1,0 +1,3 @@
+.wallet {
+  display: flex;
+}

--- a/src/components/molecules/Wallet/index.tsx
+++ b/src/components/molecules/Wallet/index.tsx
@@ -2,13 +2,21 @@ import React, { ReactElement } from 'react'
 import Account from './Account'
 import Details from './Details'
 import Tooltip from '../../atoms/Tooltip'
+import Network from './Network'
 import { useOcean } from '@oceanprotocol/react'
+import styles from './index.module.css'
 
 export default function Wallet(): ReactElement {
   const { accountId } = useOcean()
 
   return (
-    <Tooltip content={<Details />} trigger="click focus" disabled={!accountId}>
+    <Tooltip
+      content={<Details />}
+      trigger="click focus"
+      disabled={!accountId}
+      className={styles.wallet}
+    >
+      <Network />
       <Account />
     </Tooltip>
   )

--- a/src/components/molecules/Wallet/index.tsx
+++ b/src/components/molecules/Wallet/index.tsx
@@ -10,14 +10,15 @@ export default function Wallet(): ReactElement {
   const { accountId } = useOcean()
 
   return (
-    <Tooltip
-      content={<Details />}
-      trigger="click focus"
-      disabled={!accountId}
-      className={styles.wallet}
-    >
+    <div className={styles.wallet}>
       <Network />
-      <Account />
-    </Tooltip>
+      <Tooltip
+        content={<Details />}
+        trigger="click focus"
+        disabled={!accountId}
+      >
+        <Account />
+      </Tooltip>
+    </div>
   )
 }

--- a/src/hooks/useSiteMetadata.ts
+++ b/src/hooks/useSiteMetadata.ts
@@ -17,6 +17,7 @@ const query = graphql`
         appConfig {
           infuraProjectId
           network
+          supportedNetworks
           marketFeeAddress
           currencies
           portisId

--- a/src/hooks/useSiteMetadata.ts
+++ b/src/hooks/useSiteMetadata.ts
@@ -17,7 +17,6 @@ const query = graphql`
         appConfig {
           infuraProjectId
           network
-          supportedNetworks
           marketFeeAddress
           currencies
           portisId

--- a/src/utils/wallet.ts
+++ b/src/utils/wallet.ts
@@ -1,7 +1,20 @@
 import { infuraProjectId as infuraId, portisId } from '../../app.config'
 import WalletConnectProvider from '@walletconnect/web3-provider'
-import axios, { CancelToken } from 'axios'
+import axios, { AxiosResponse, CancelToken } from 'axios'
 import { Logger } from '@oceanprotocol/lib'
+
+export interface EthereumListsChain {
+  name: string
+  chainId: number
+  shortName: string
+  chain: string
+  network: string
+  networkId: number
+  nativeCurrency: { name: string; symbol: string; decimals: number }
+  rpc: string[]
+  faucets: string[]
+  infoURL: string
+}
 
 const web3ModalTheme = {
   background: 'var(--background-body)',
@@ -55,14 +68,17 @@ export function accountTruncate(account: string): string {
 export async function getNetworkData(
   networkId: number,
   cancelToken: CancelToken
-): Promise<any> {
+): Promise<EthereumListsChain> {
   if (!networkId) return
 
   try {
     // https://github.com/ethereum-lists/chains
-    const response = await axios('https://chainid.network/chains.json', {
-      cancelToken
-    })
+    const response: AxiosResponse<EthereumListsChain[]> = await axios(
+      'https://chainid.network/chains.json',
+      {
+        cancelToken
+      }
+    )
     const network = response.data.filter(
       (item: { networkId: number }) => item.networkId === networkId
     )[0]

--- a/src/utils/wallet.ts
+++ b/src/utils/wallet.ts
@@ -70,7 +70,7 @@ function getNetworkDisplayName(
   networkId: number
 ): string {
   const displayName = data
-    ? `${data.chain} ${data.network}`
+    ? `${data.chain} ${data.network === 'mainnet' ? '' : data.network}`
     : networkId === 8996
     ? 'Development'
     : 'Unknown'

--- a/src/utils/wallet.ts
+++ b/src/utils/wallet.ts
@@ -1,7 +1,5 @@
 import { infuraProjectId as infuraId, portisId } from '../../app.config'
 import WalletConnectProvider from '@walletconnect/web3-provider'
-import axios, { AxiosResponse, CancelToken } from 'axios'
-import { Logger } from '@oceanprotocol/lib'
 
 export interface EthereumListsChain {
   name: string
@@ -65,7 +63,7 @@ export function accountTruncate(account: string): string {
   return truncated
 }
 
-function getNetworkDisplayName(
+export function getNetworkDisplayName(
   data: EthereumListsChain,
   networkId: number
 ): string {
@@ -78,30 +76,12 @@ function getNetworkDisplayName(
   return displayName
 }
 
-export async function getNetworkData(
-  networkId: number,
-  cancelToken: CancelToken
-): Promise<{ displayName: string; data: EthereumListsChain }> {
-  // https://github.com/ethereum-lists/chains
-  const chainDataUrl = 'https://chainid.network/chains.json'
-
-  try {
-    const response: AxiosResponse<
-      EthereumListsChain[]
-    > = await axios(chainDataUrl, { cancelToken })
-    const data = response.data.filter(
-      (item: { networkId: number }) => item.networkId === networkId
-    )[0]
-    const displayName = getNetworkDisplayName(data, networkId)
-
-    return { displayName, data }
-  } catch (error) {
-    if (axios.isCancel(error)) {
-      Logger.log(error.message)
-    } else {
-      Logger.error(
-        `Could not fetch from chainid.network/chains.json: ${error.message}`
-      )
-    }
-  }
+export function getNetworkData(
+  data: { node: EthereumListsChain }[],
+  networkId: number
+): EthereumListsChain {
+  const networkData = data.filter(
+    ({ node }: { node: EthereumListsChain }) => node.networkId === networkId
+  )[0]
+  return networkData.node
 }


### PR DESCRIPTION
Fixes #412.

Changes proposed in this PR:

- move network detection and warning out of generic Web3 feedback component, so it's not displayed in popover anymore
- output beside account button, based on app config or user network
- output nothing when connected to Mainnet
- fetch chain metadata from [ethereum-lists/chains](https://github.com/ethereum-lists/chains) on build time, for mapping `networkId` to display name among other things
- detect supported networks based on ocean.js `ConfigHelper` configs, and error icon output based on it
- cleanup `utils/wallet.ts`, remove unused or redundant methods

Resulting in:

Supported & test network:

<img width="425" alt="Screen Shot 2021-03-03 at 03 12 34" src="https://user-images.githubusercontent.com/90316/109741887-508f9a80-7bce-11eb-853c-a1b22c50bd41.png">

Unsupported & test network:

<img width="546" alt="Screen Shot 2021-03-03 at 03 38 18" src="https://user-images.githubusercontent.com/90316/109744024-eed12f80-7bd1-11eb-90a8-fee9b98cb530.png">

