### PR TITLE
hotfix for asset details

### DIFF
--- a/src/components/atoms/EtherscanLink.tsx
+++ b/src/components/atoms/EtherscanLink.tsx
@@ -36,12 +36,14 @@ export default function EtherscanLink({
   const [url, setUrl] = useState<string>()
 
   useEffect(() => {
-    const networkData = getNetworkData(networksList, networkId)
+    const networkData = networkId
+      ? getNetworkData(networksList, networkId)
+      : null
     const url =
       (!networkId && appConfig.network === 'mainnet') || networkId === 1
         ? `https://etherscan.io`
         : `https://${
-            networkId ? networkData.network : appConfig.network
+            networkData ? networkData.network : appConfig.network
           }.etherscan.io`
 
     setUrl(url)

--- a/src/components/organisms/AssetContent/EditHistory.tsx
+++ b/src/components/organisms/AssetContent/EditHistory.tsx
@@ -8,7 +8,7 @@ import { gql, useQuery } from '@apollo/client'
 import { ReceiptData_datatokens_updates as ReceiptData } from '../../../@types/apollo/ReceiptData'
 
 const getReceipts = gql`
-  query ReceiptData($address: String!) {
+  query ReceiptData($address: ID!) {
     datatokens(where: { id: $address }) {
       createTime
       tx


### PR DESCRIPTION
* was broken in non-web3 browsers
* missed in https://github.com/oceanprotocol/market/pull/421
* fixes e.g. blank screen on mobile reported in #424