### PR TITLE
Fix/ Algorithm assets query for start compute

### DIFF
--- a/src/components/organisms/AssetActions/Compute/index.tsx
+++ b/src/components/organisms/AssetActions/Compute/index.tsx
@@ -148,7 +148,7 @@ export default function Compute({
     trustedAlgorithmList.forEach((trusteAlgo) => {
       algoQuerry += `id:"${trusteAlgo.did}" OR `
     })
-    if (trustedAlgorithmList.length > 1) {
+    if (trustedAlgorithmList.length >= 1) {
       algoQuerry = algoQuerry.substring(0, algoQuerry.length - 3)
     }
     const algorithmQuery =


### PR DESCRIPTION
Fixes #.

Changes proposed in this PR:

- fixes get algorithm assets query when only one trusted algorithm is set
