### PR TITLE
output datatoken symbol for each asset in asset selection

### DIFF
--- a/src/components/molecules/FormFields/AssetSelection.tsx
+++ b/src/components/molecules/FormFields/AssetSelection.tsx
@@ -15,6 +15,7 @@ export interface AssetSelectionAsset {
   name: string
   price: string
   checked: boolean
+  symbol: string
 }
 
 function Empty() {
@@ -99,7 +100,7 @@ export default function AssetSelection({
                   </h3>
 
                   <Dotdotdot clamp={1} tagName="code" className={styles.did}>
-                    {asset.did}
+                    {asset.symbol} | {asset.did}
                   </Dotdotdot>
                 </label>
 

--- a/src/utils/aquarius.ts
+++ b/src/utils/aquarius.ts
@@ -114,9 +114,11 @@ export async function transformDDOToAssetSelection(
   const source = axios.CancelToken.source()
   const didList: string[] = []
   const priceList: any = {}
+  const symbolList: any = {}
   ddoList.forEach((ddo: DDO) => {
     didList.push(ddo.id)
     priceList[ddo.id] = ddo.price.value
+    symbolList[ddo.id] = ddo.dataTokenInfo.symbol
   })
   const ddoNames = await getAssetsNames(didList, metadataCacheUri, source.token)
   const algorithmList: AssetSelectionAsset[] = []
@@ -132,13 +134,15 @@ export async function transformDDOToAssetSelection(
           did: did,
           name: ddoNames[did],
           price: priceList[did],
-          checked: selected
+          checked: selected,
+          symbol: symbolList[did]
         })
       : algorithmList.push({
           did: did,
           name: ddoNames[did],
           price: priceList[did],
-          checked: selected
+          checked: selected,
+          symbol: symbolList[did]
         })
   })
   return algorithmList


### PR DESCRIPTION
Fixes #472  .

Changes proposed in this PR:

- output the datatoken symbol for each asset in asset selection