### PR TITLE
Feature/459 Check dataset connectivity on asset detail page

### DIFF
--- a/src/components/organisms/AssetActions/Consume.tsx
+++ b/src/components/organisms/AssetActions/Consume.tsx
@@ -124,15 +124,20 @@ export default function Consume({
   }, [dtBalance])
 
   useEffect(() => {
-    setIsDisabled(
-      (!ocean ||
-        !isBalanceSufficient ||
-        typeof consumeStepText !== 'undefined' ||
-        pricingIsLoading ||
-        !isConsumable) &&
-        !hasPreviousOrder &&
-        !hasDatatoken
-    )
+    async function validateAsset() {
+      const isFileValid = await ocean.provider.fileinfo(ddo.id)
+      setIsDisabled(
+        (!ocean ||
+          !isBalanceSufficient ||
+          typeof consumeStepText !== 'undefined' ||
+          pricingIsLoading ||
+          !isConsumable) &&
+          !hasPreviousOrder &&
+          !hasDatatoken &&
+          !isFileValid
+      )
+    }
+    validateAsset()
   }, [
     ocean,
     hasPreviousOrder,
@@ -140,10 +145,12 @@ export default function Consume({
     consumeStepText,
     pricingIsLoading,
     isConsumable,
-    hasDatatoken
+    hasDatatoken,
+    ddo.id
   ])
 
   async function handleConsume() {
+    // TODO : check fileinfo
     !hasPreviousOrder && !hasDatatoken && (await buyDT('1', price))
     await consume(
       ddo.id,

--- a/src/components/organisms/AssetActions/Consume.tsx
+++ b/src/components/organisms/AssetActions/Consume.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement, useEffect, useState } from 'react'
 import { toast } from 'react-toastify'
-import { File as FileMetadata, DDO } from '@oceanprotocol/lib'
+import { File as FileMetadata, DDO, DID, Logger } from '@oceanprotocol/lib'
 import Button from '../../atoms/Button'
 import File from '../../atoms/File'
 import Price from '../../atoms/Price'
@@ -125,7 +125,16 @@ export default function Consume({
 
   useEffect(() => {
     async function validateAsset() {
-      const isFileValid = await ocean.provider.fileinfo(ddo.id)
+      let isFileValid: boolean
+      try {
+        const did = DID.parse(ddo.id)
+        const file = (await ocean.provider.fileinfo(did)) as any
+        isFileValid = file[0].valid
+      } catch (error) {
+        Logger.error(error)
+        isFileValid = false
+      }
+
       setIsDisabled(
         (!ocean ||
           !isBalanceSufficient ||


### PR DESCRIPTION
Fixes #459 

Changes proposed in this PR:
- On mount of consume and `Buy/Download` click, check dataset connectivity using `ocean.provider.fileinfo(did)` 