### PR TITLE
show assets ordered by creation time

### DIFF
--- a/src/components/pages/History/PublishedList.tsx
+++ b/src/components/pages/History/PublishedList.tsx
@@ -29,7 +29,7 @@ export default function PublishedList(): ReactElement {
             query: `(publicKey.owner:${accountId})`
           }
         },
-        sort: { 'price.ocean': -1 }
+        sort: { created: -1 }
       }
       try {
         queryResult || setIsLoading(true)


### PR DESCRIPTION
Fixes #484.

Changes proposed in this PR:

- show published assets ordered by creation time
