### PR TITLE
limit price precision to 18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16410,7 +16410,7 @@
       }
     },
     "ethereumjs-abi": {
-      "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#1a27c59c15ab1e95ee8e5c4ed6ad814c49cc439e",
+      "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#1ce6a1d64235fabe2aaf827fd606def55693508f",
       "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
       "requires": {
         "bn.js": "^4.11.8",

--- a/src/hooks/usePricing.ts
+++ b/src/hooks/usePricing.ts
@@ -129,12 +129,20 @@ function usePricing(ddo: DDO): UsePricing {
       setStep(1, 'buy')
 
       Logger.log('Price found for buying', price)
+      Decimal.set({ precision: 18 })
+
       switch (price?.type) {
         case 'pool': {
           const oceanAmmount = new Decimal(price.value).times(1.05).toString()
           const maxPrice = new Decimal(price.value).times(2).toString()
           setStep(2, 'buy')
-          Logger.log('Buying token from pool', price, accountId, price)
+          Logger.log(
+            'Buying token from pool',
+            price,
+            accountId,
+            oceanAmmount,
+            maxPrice
+          )
           tx = await ocean.pool.buyDT(
             accountId,
             price.address,
@@ -190,6 +198,7 @@ function usePricing(ddo: DDO): UsePricing {
   ): Promise<TransactionReceipt | void> {
     if (!ocean || !accountId) return
 
+    Decimal.set({ precision: 18 })
     if (!config.oceanTokenAddress) {
       Logger.error(`'oceanTokenAddress' not set in config`)
       return


### PR DESCRIPTION
Limit price precision to 18 in calculations because `web3.utils.toWei` is limited to 18 decimals