### PR TITLE
Removing tooltip animation onHover

### DIFF
--- a/src/components/organisms/AssetActions/Pool/Graph.tsx
+++ b/src/components/organisms/AssetActions/Pool/Graph.tsx
@@ -77,6 +77,10 @@ function getOptions(locale: string, isDarkMode: boolean): ChartOptions {
     legend: {
       display: false
     },
+    hover: {
+      intersect: false,
+      animationDuration: 0
+    },
     scales: {
       yAxes: [
         {


### PR DESCRIPTION
Fixes #390 

Changes proposed in this PR:
- removes the animation for the tooltip window onHover
- sets intersect to false for the tooltip window onHover