### PR TITLE
Add liquidity warning message is empty

### DIFF
--- a/src/components/organisms/AssetActions/Pool/Add/index.tsx
+++ b/src/components/organisms/AssetActions/Pool/Add/index.tsx
@@ -174,7 +174,7 @@ export default function Add({
               ) : (
                 <Alert
                   className={styles.warning}
-                  text={content.warning.main}
+                  text={content.warning}
                   state="info"
                   action={{
                     name: 'I understand',


### PR DESCRIPTION
Fixes #511 .

Changes proposed in this PR:

- fix empty warning displayed inside dataset pool, after click on ADD LIQUIDITY button