### PR TITLE
more reliable isOwner check

### DIFF
--- a/src/components/organisms/AssetContent/index.tsx
+++ b/src/components/organisms/AssetContent/index.tsx
@@ -46,13 +46,16 @@ export default function AssetContent(props: AssetContentProps): ReactElement {
   const { owner, isInPurgatory, purgatoryData } = useAsset()
   const [showPricing, setShowPricing] = useState(false)
   const [showEdit, setShowEdit] = useState<boolean>()
+  const [isOwner, setIsOwner] = useState(false)
   const { ddo, price, metadata } = useAsset()
-  const isOwner = accountId === owner
 
   useEffect(() => {
-    if (!price) return
+    if (!accountId || !owner) return
+
+    const isOwner = accountId.toLowerCase() === owner.toLowerCase()
+    setIsOwner(isOwner)
     setShowPricing(isOwner && price.type === '')
-  }, [isOwner, price])
+  }, [accountId, price, owner])
 
   function handleEditButton() {
     // move user's focus to top of screen


### PR DESCRIPTION
Ran into issues with switching accounts on the asset details page where the owner actions did not show up in some cases, or were not shown when first arriving at asset details page.

This PR makes this more reliable by:
- moving `isOwner` into an effect
- lowercasing account & owner addresses for comparison