### PR TITLE
Making searchbar appear in all assets

### DIFF
--- a/src/components/molecules/SearchBar.tsx
+++ b/src/components/molecules/SearchBar.tsx
@@ -17,7 +17,7 @@ export default function SearchBar({
   filters?: boolean
   size?: 'small' | 'large'
 }): ReactElement {
-  let [value, setValue] = useState(initialValue || '')
+  const [value, setValue] = useState(initialValue || '')
 
   function handleChange(e: ChangeEvent<HTMLInputElement>) {
     setValue(e.target.value)
@@ -25,7 +25,7 @@ export default function SearchBar({
 
   async function startSearch(e: FormEvent<HTMLButtonElement>) {
     e.preventDefault()
-    if (value === '') value = ' '
+    if (value === '') setValue(' ')
     const urlEncodedValue = encodeURIComponent(value)
     const url = await addExistingParamsToUrl(location, 'text')
     navigate(`${url}&text=${urlEncodedValue}`)

--- a/src/components/molecules/SearchBar.tsx
+++ b/src/components/molecules/SearchBar.tsx
@@ -17,7 +17,7 @@ export default function SearchBar({
   filters?: boolean
   size?: 'small' | 'large'
 }): ReactElement {
-  const [value, setValue] = useState(initialValue || '')
+  let [value, setValue] = useState(initialValue || '')
 
   function handleChange(e: ChangeEvent<HTMLInputElement>) {
     setValue(e.target.value)
@@ -25,7 +25,7 @@ export default function SearchBar({
 
   async function startSearch(e: FormEvent<HTMLButtonElement>) {
     e.preventDefault()
-    if (value === '') return
+    if (value === '') value = ' '
     const urlEncodedValue = encodeURIComponent(value)
     const url = await addExistingParamsToUrl(location, 'text')
     navigate(`${url}&text=${urlEncodedValue}`)

--- a/src/components/pages/Home.tsx
+++ b/src/components/pages/Home.tsx
@@ -109,7 +109,11 @@ export default function HomePage(): ReactElement {
         action={
           <Button
             style="text"
-            to="/search?priceType=pool&sort=liquidity&sortOrder=desc&text=%20"
+            to={
+              screen.width > 480
+                ? '/search?priceType=pool&sort=liquidity&sortOrder=desc&text=%20'
+                : '/search?priceType=pool&sort=liquidity&sortOrder=desc'
+            }
           >
             All data sets with pool →
           </Button>
@@ -122,7 +126,11 @@ export default function HomePage(): ReactElement {
         action={
           <Button
             style="text"
-            to="/search?sort=created&sortOrder=desc&text=%20"
+            to={
+              screen.width > 480
+                ? '/search?priceType=pool&sort=liquidity&sortOrder=desc&text=%20'
+                : '/search?priceType=pool&sort=liquidity&sortOrder=desc'
+            }
           >
             All data sets →
           </Button>

--- a/src/components/pages/Home.tsx
+++ b/src/components/pages/Home.tsx
@@ -109,7 +109,7 @@ export default function HomePage(): ReactElement {
         action={
           <Button
             style="text"
-            to="/search?priceType=pool&sort=liquidity&sortOrder=desc"
+            to="/search?priceType=pool&sort=liquidity&sortOrder=desc&text=%20"
           >
             All data sets with pool →
           </Button>

--- a/src/components/pages/Home.tsx
+++ b/src/components/pages/Home.tsx
@@ -120,7 +120,10 @@ export default function HomePage(): ReactElement {
         title="Recently Published"
         query={queryLatest}
         action={
-          <Button style="text" to="/search?sort=created&sortOrder=desc">
+          <Button
+            style="text"
+            to="/search?sort=created&sortOrder=desc&text=%20"
+          >
             All data sets →
           </Button>
         }

--- a/src/components/templates/Search/index.tsx
+++ b/src/components/templates/Search/index.tsx
@@ -43,7 +43,7 @@ export default function SearchPage({
     }
     initSearch()
   }, [
-    text,
+    'text', // text,
     owner,
     tags,
     sort,

--- a/src/components/templates/Search/index.tsx
+++ b/src/components/templates/Search/index.tsx
@@ -43,7 +43,7 @@ export default function SearchPage({
     }
     initSearch()
   }, [
-    'text', // text,
+    text,
     owner,
     tags,
     sort,

--- a/src/pages/search.tsx
+++ b/src/pages/search.tsx
@@ -16,7 +16,6 @@ export default function PageGatsbySearch(props: PageProps): ReactElement {
     (isETHAddress ? accountTruncate(text as string) : text) ||
     tags ||
     categories
-  console.log('searchValue', searchValue)
   const title = owner
     ? `Published by ${accountTruncate(owner as string)}`
     : `${

--- a/src/pages/search.tsx
+++ b/src/pages/search.tsx
@@ -16,11 +16,12 @@ export default function PageGatsbySearch(props: PageProps): ReactElement {
     (isETHAddress ? accountTruncate(text as string) : text) ||
     tags ||
     categories
+  console.log('searchValue', searchValue)
   const title = owner
     ? `Published by ${accountTruncate(owner as string)}`
     : `${
         totalResults !== undefined
-          ? searchValue
+          ? searchValue && searchValue !== ' '
             ? totalResults === 0
               ? 'No results'
               : totalResults +


### PR DESCRIPTION
Closes: https://github.com/oceanprotocol/market/issues/335

Changes proposed in this PR:
- Small change to the redirect URL to make sure that the search bar is still shown when the user clicks on "all data assets"