### PR TITLE
Fix setting subgraph sync status

### DIFF
--- a/src/hooks/useGraphSyncStatus.ts
+++ b/src/hooks/useGraphSyncStatus.ts
@@ -77,6 +77,7 @@ export function useGraphSyncStatus(): UseGraphSyncStatus {
   // Get and set subgraph block
   useEffect(() => {
     if (!config || !config.subgraphUri) return
+
     async function initBlockSubgraph() {
       setSubgraphLoading(true)
       const blockGraph = await getBlockSubgraph(config.subgraphUri)
@@ -98,7 +99,7 @@ export function useGraphSyncStatus(): UseGraphSyncStatus {
       return
     }
     setIsGraphSynced(true)
-  }, [blockGraph, blockHead])
+  }, [blockGraph, blockHead, web3Loading, subgraphLoading])
 
   return { blockHead, blockGraph, isGraphSynced }
 }


### PR DESCRIPTION
Hopefully last fix for that random behavior of the sync banner when switching networks. Basically we stopped updating `isGraphSynced` whenever web3 or graph was loading and then did not fire the effect again once those two states were updated