### PR TITLE
Fix edge case calculation errors in remove liquidity screen

### DIFF
--- a/src/components/organisms/AssetActions/Pool/Remove.tsx
+++ b/src/components/organisms/AssetActions/Pool/Remove.tsx
@@ -86,6 +86,12 @@ export default function Remove({
   async function handleRemoveLiquidity() {
     setIsLoading(true)
     try {
+      console.log(
+        'remove liquidity with',
+        amountPoolShares,
+        minDatatokenAmount,
+        minOceanAmount
+      )
       const result =
         isAdvanced === true
           ? await ocean.pool.removePoolLiquidity(

--- a/src/components/organisms/AssetActions/Pool/Remove.tsx
+++ b/src/components/organisms/AssetActions/Pool/Remove.tsx
@@ -81,7 +81,7 @@ export default function Remove({
   const [minOceanAmount, setMinOceanAmount] = useState<string>('0')
   const [minDatatokenAmount, setMinDatatokenAmount] = useState<string>('0')
 
-  Decimal.set({ toExpNeg: -18, precision: 16, rounding: 1 })
+  Decimal.set({ toExpNeg: -18, precision: 18, rounding: 1 })
 
   async function handleRemoveLiquidity() {
     setIsLoading(true)
@@ -176,10 +176,7 @@ export default function Remove({
       .dividedBy(100)
       .mul(new Decimal(poolTokens))
       .toString()
-
-    console.log('shares slider', Decimal.precision, amountPoolShares)
-
-    setAmountPoolShares(`${amountPoolShares}`)
+    setAmountPoolShares(`${amountPoolShares.slice(0, 18)}`)
   }
 
   function handleMaxButton(e: ChangeEvent<HTMLInputElement>) {

--- a/src/components/organisms/AssetActions/Pool/Remove.tsx
+++ b/src/components/organisms/AssetActions/Pool/Remove.tsx
@@ -175,9 +175,6 @@ export default function Remove({
       .mul(new Decimal(poolTokens))
       .toFixed(18, Decimal.ROUND_DOWN) // in some cases the returned value contain more than 18 digits which break conversion to wei
 
-      console.log('amountPoolShares = ', amountPoolShares)
-      console.log('amountPoolShares.toString = ', amountPoolShares.toString())
-
     setAmountPoolShares(`${amountPoolShares}`)
   }
 
@@ -189,8 +186,6 @@ export default function Remove({
       .dividedBy(100)
       .mul(new Decimal(poolTokens))
       .toFixed(18, Decimal.ROUND_DOWN)
-
-    console.log('amountPoolShares = ', amountPoolShares)
 
     setAmountPoolShares(`${amountPoolShares}`)
   }

--- a/src/components/organisms/AssetActions/Pool/Remove.tsx
+++ b/src/components/organisms/AssetActions/Pool/Remove.tsx
@@ -81,6 +81,8 @@ export default function Remove({
   const [minOceanAmount, setMinOceanAmount] = useState<string>('0')
   const [minDatatokenAmount, setMinDatatokenAmount] = useState<string>('0')
 
+  Decimal.set({ toExpNeg: -18, precision: 16, rounding: 1 })
+
   async function handleRemoveLiquidity() {
     setIsLoading(true)
     try {
@@ -170,12 +172,12 @@ export default function Remove({
     setAmountPercent(e.target.value)
     if (!poolTokens) return
 
-    Decimal.set({ toExpPos: 2 })
-
     const amountPoolShares = new Decimal(e.target.value)
       .dividedBy(100)
       .mul(new Decimal(poolTokens))
       .toString()
+
+    console.log('shares slider', Decimal.precision, amountPoolShares)
 
     setAmountPoolShares(`${amountPoolShares}`)
   }
@@ -183,8 +185,6 @@ export default function Remove({
   function handleMaxButton(e: ChangeEvent<HTMLInputElement>) {
     e.preventDefault()
     setAmountPercent(amountMaxPercent)
-
-    Decimal.set({ toExpPos: 2 })
 
     const amountPoolShares = new Decimal(amountMaxPercent)
       .dividedBy(100)

--- a/src/components/organisms/AssetActions/Pool/Remove.tsx
+++ b/src/components/organisms/AssetActions/Pool/Remove.tsx
@@ -86,12 +86,6 @@ export default function Remove({
   async function handleRemoveLiquidity() {
     setIsLoading(true)
     try {
-      console.log(
-        'remove liquidity with',
-        amountPoolShares,
-        minDatatokenAmount,
-        minOceanAmount
-      )
       const result =
         isAdvanced === true
           ? await ocean.pool.removePoolLiquidity(
@@ -165,12 +159,18 @@ export default function Remove({
   ])
 
   useEffect(() => {
-    const minOceanAmount =
-      (Number(amountOcean) * (100 - Number(slippage))) / 100
-    const minDatatokenAmount =
-      (Number(amountDatatoken) * (100 - Number(slippage))) / 100
-    setMinOceanAmount(minOceanAmount.toString().slice(0, 18))
-    setMinDatatokenAmount(minDatatokenAmount.toString().slice(0, 18))
+    const minOceanAmount = new Decimal(amountOcean)
+      .mul(new Decimal(100).minus(new Decimal(slippage)))
+      .dividedBy(100)
+      .toString()
+
+    const minDatatokenAmount = new Decimal(amountDatatoken)
+      .mul(new Decimal(100).minus(new Decimal(slippage)))
+      .dividedBy(100)
+      .toString()
+
+    setMinOceanAmount(minOceanAmount.slice(0, 18))
+    setMinDatatokenAmount(minDatatokenAmount.slice(0, 18))
   }, [slippage, amountOcean, amountDatatoken, isAdvanced])
 
   // Set amountPoolShares based on set slider value

--- a/src/components/organisms/AssetActions/Pool/Remove.tsx
+++ b/src/components/organisms/AssetActions/Pool/Remove.tsx
@@ -170,10 +170,12 @@ export default function Remove({
     setAmountPercent(e.target.value)
     if (!poolTokens) return
 
+    Decimal.set({ toExpPos: 2 })
+
     const amountPoolShares = new Decimal(e.target.value)
       .dividedBy(100)
       .mul(new Decimal(poolTokens))
-      .toFixed(18, Decimal.ROUND_DOWN) // in some cases the returned value contain more than 18 digits which break conversion to wei
+      .toString()
 
     setAmountPoolShares(`${amountPoolShares}`)
   }
@@ -182,10 +184,12 @@ export default function Remove({
     e.preventDefault()
     setAmountPercent(amountMaxPercent)
 
+    Decimal.set({ toExpPos: 2 })
+
     const amountPoolShares = new Decimal(amountMaxPercent)
       .dividedBy(100)
       .mul(new Decimal(poolTokens))
-      .toFixed(18, Decimal.ROUND_DOWN)
+      .toString()
 
     setAmountPoolShares(`${amountPoolShares}`)
   }

--- a/src/components/organisms/AssetActions/Pool/Remove.tsx
+++ b/src/components/organisms/AssetActions/Pool/Remove.tsx
@@ -173,7 +173,10 @@ export default function Remove({
     const amountPoolShares = new Decimal(e.target.value)
       .dividedBy(100)
       .mul(new Decimal(poolTokens))
-      .toFixed(18) // in some cases the returned value contain more than 18 digits which break conversion to wei
+      .toFixed(18, Decimal.ROUND_DOWN) // in some cases the returned value contain more than 18 digits which break conversion to wei
+
+      console.log('amountPoolShares = ', amountPoolShares)
+      console.log('amountPoolShares.toString = ', amountPoolShares.toString())
 
     setAmountPoolShares(`${amountPoolShares}`)
   }
@@ -185,7 +188,9 @@ export default function Remove({
     const amountPoolShares = new Decimal(amountMaxPercent)
       .dividedBy(100)
       .mul(new Decimal(poolTokens))
-      .toFixed(18)
+      .toFixed(18, Decimal.ROUND_DOWN)
+
+    console.log('amountPoolShares = ', amountPoolShares)
 
     setAmountPoolShares(`${amountPoolShares}`)
   }

--- a/src/components/organisms/AssetActions/Pool/Remove.tsx
+++ b/src/components/organisms/AssetActions/Pool/Remove.tsx
@@ -163,8 +163,8 @@ export default function Remove({
       (Number(amountOcean) * (100 - Number(slippage))) / 100
     const minDatatokenAmount =
       (Number(amountDatatoken) * (100 - Number(slippage))) / 100
-    setMinOceanAmount(`${minOceanAmount}`)
-    setMinDatatokenAmount(`${minDatatokenAmount}`)
+    setMinOceanAmount(minOceanAmount.toString().slice(0, 18))
+    setMinDatatokenAmount(minDatatokenAmount.toString().slice(0, 18))
   }, [slippage, amountOcean, amountDatatoken, isAdvanced])
 
   // Set amountPoolShares based on set slider value
@@ -176,6 +176,7 @@ export default function Remove({
       .dividedBy(100)
       .mul(new Decimal(poolTokens))
       .toString()
+
     setAmountPoolShares(`${amountPoolShares.slice(0, 18)}`)
   }
 

--- a/src/components/organisms/AssetActions/Pool/Remove.tsx
+++ b/src/components/organisms/AssetActions/Pool/Remove.tsx
@@ -188,7 +188,7 @@ export default function Remove({
       .mul(new Decimal(poolTokens))
       .toString()
 
-    setAmountPoolShares(`${amountPoolShares}`)
+    setAmountPoolShares(`${amountPoolShares.slice(0, 18)}`)
   }
 
   function handleAdvancedButton(e: FormEvent<HTMLButtonElement>) {

--- a/src/components/organisms/AssetActions/Pool/Remove.tsx
+++ b/src/components/organisms/AssetActions/Pool/Remove.tsx
@@ -173,7 +173,7 @@ export default function Remove({
     const amountPoolShares = new Decimal(e.target.value)
       .dividedBy(100)
       .mul(new Decimal(poolTokens))
-      .toPrecision(18) // in some cases the returned value contain more than 18 digits which break conversion to wei
+      .toFixed(18) // in some cases the returned value contain more than 18 digits which break conversion to wei
 
     setAmountPoolShares(`${amountPoolShares}`)
   }
@@ -185,7 +185,7 @@ export default function Remove({
     const amountPoolShares = new Decimal(amountMaxPercent)
       .dividedBy(100)
       .mul(new Decimal(poolTokens))
-      .toPrecision(18)
+      .toFixed(18)
 
     setAmountPoolShares(`${amountPoolShares}`)
   }


### PR DESCRIPTION
Fixes #584  .

Changes proposed in this PR:

- making sure any number has 18 decimals at all times, since `toPrecision()` alone led to errors in certain edge cases