### PR TITLE
Show tabs without relying on the ddo price type

### DIFF
--- a/src/components/organisms/AssetActions/index.tsx
+++ b/src/components/organisms/AssetActions/index.tsx
@@ -18,7 +18,6 @@ export default function AssetActions(): ReactElement {
 
   const [isBalanceSufficient, setIsBalanceSufficient] = useState<boolean>()
   const [dtBalance, setDtBalance] = useState<string>()
-
   const isCompute = Boolean(ddo?.findServiceByType('compute'))
 
   // Get and set user DT balance
@@ -74,10 +73,7 @@ export default function AssetActions(): ReactElement {
     }
   ]
 
-  // Check from metadata, cause that is available earlier
-  const hasPool = ddo?.price?.type === 'pool'
-
-  hasPool &&
+  price?.type === 'pool' &&
     tabs.push(
       {
         title: 'Pool',


### PR DESCRIPTION
Fixes #499 .

Changes proposed in this PR:

- Use price type from useAsset() to show asset actions tabs