### PR TITLE
Making asset unavailable for purchase if the size is zero

### DIFF
--- a/src/components/organisms/AssetActions/Consume.tsx
+++ b/src/components/organisms/AssetActions/Consume.tsx
@@ -167,7 +167,11 @@ export default function Consume({
         </div>
         <div className={styles.pricewrapper}>
           <Price price={price} conversion />
-          {!isInPurgatory && <PurchaseButton />}
+          {parseInt(file?.contentLength) === 0 ? (
+            <p>This asset is currently unavailable for purchase.</p>
+          ) : (
+            !isInPurgatory && <PurchaseButton />
+          )}
         </div>
       </div>
       <footer className={styles.feedback}>


### PR DESCRIPTION
Closes:

Changes proposed in this PR:
- Checking if the file size is 0
- Making the asset unavailable if the file size is zero