### PR TITLE
fix assets from mainnet displayed on rinkeby inside the home page

### DIFF
--- a/src/components/pages/Home.tsx
+++ b/src/components/pages/Home.tsx
@@ -12,6 +12,7 @@ import Button from '../atoms/Button'
 import Bookmarks from '../molecules/Bookmarks'
 import axios from 'axios'
 import { queryMetadata } from '../../utils/aquarius'
+import { useWeb3 } from '../../providers/Web3'
 
 const queryHighest = {
   page: 1,
@@ -46,10 +47,10 @@ function SectionQueryResult({
 }) {
   const { config } = useOcean()
   const [result, setResult] = useState<QueryResult>()
+  const { web3Loading } = useWeb3()
 
   useEffect(() => {
-    if (!config?.metadataCacheUri) return
-
+    if (!config?.metadataCacheUri || web3Loading) return
     const source = axios.CancelToken.source()
 
     async function init() {
@@ -65,7 +66,7 @@ function SectionQueryResult({
     return () => {
       source.cancel()
     }
-  }, [config?.metadataCacheUri, query])
+  }, [config?.metadataCacheUri, query, web3Loading])
 
   return (
     <section className={styles.section}>

--- a/src/providers/Web3.tsx
+++ b/src/providers/Web3.tsx
@@ -150,7 +150,10 @@ function Web3Provider({ children }: { children: ReactNode }): ReactElement {
   // Create initial Web3Modal instance
   // -----------------------------------
   useEffect(() => {
-    if (web3Modal) return
+    if (web3Modal) {
+      setWeb3Loading(false)
+      return
+    }
 
     async function init() {
       // note: needs artificial await here so the log message is reached and output


### PR DESCRIPTION
Fixes #602 .

Changes proposed in this PR:

-Fix the asset retrieving method from home page to get only the assets from the current network config 