### PR TITLE
fix Add Liquidity screen crashes whole app without wallet

### DIFF
--- a/src/components/organisms/AssetActions/Pool/Add/FormAdd.tsx
+++ b/src/components/organisms/AssetActions/Pool/Add/FormAdd.tsx
@@ -90,7 +90,7 @@ export default function FormAdd({
     amountMax,
     coin,
     poolAddress,
-    ocean.pool,
+    ocean?.pool,
     setNewPoolTokens,
     setNewPoolShare
   ])


### PR DESCRIPTION
Fixes #626 .

Changes proposed in this PR:

- fix Add Liquidity screen crashes whole app without wallet