### PR TITLE
Pool statistics graph shows two sets of data when switching tabs

### DIFF
--- a/src/components/organisms/AssetActions/Pool/Graph.tsx
+++ b/src/components/organisms/AssetActions/Pool/Graph.tsx
@@ -146,11 +146,10 @@ export default function Graph(): ReactElement {
   }, [locale, darkMode.value])
 
   useEffect(() => {
-    if (!data) return
+    if (!data || data.poolTransactions.length === 0) return
     Logger.log('Fired GraphData!')
 
     const latestTimestamps = [
-      ...timestamps,
       ...data.poolTransactions.map((item) => {
         const date = new Date(item.timestamp * 1000)
         return `${date.toLocaleDateString()} ${date.toLocaleTimeString()}`
@@ -160,27 +159,24 @@ export default function Graph(): ReactElement {
     setTimestamps(latestTimestamps)
 
     const latestLiquidtyHistory = [
-      ...liquidityHistory,
       ...data.poolTransactions.map((item) => item.oceanReserve)
     ]
 
     setLiquidityHistory(latestLiquidtyHistory)
 
     const latestPriceHistory = [
-      ...priceHistory,
       ...data.poolTransactions.map((item) => item.spotPrice)
     ]
     setPriceHistory(latestPriceHistory)
 
-    if (data.poolTransactions.length > 0) {
+    if (data.poolTransactions.length < 0) {
       setLastBlock(
         data.poolTransactions[data.poolTransactions.length - 1].block
       )
       refetch()
     } else {
-      setIsLoading(false)
       setGraphData({
-        labels: timestamps.slice(0),
+        labels: latestTimestamps.slice(0),
         datasets: [
           {
             ...lineStyle,
@@ -194,6 +190,7 @@ export default function Graph(): ReactElement {
           }
         ]
       })
+      setIsLoading(false)
     }
   }, [data, graphType])
 

--- a/src/components/organisms/AssetActions/Pool/Graph.tsx
+++ b/src/components/organisms/AssetActions/Pool/Graph.tsx
@@ -123,7 +123,10 @@ export default function Graph(): ReactElement {
 
   const { price } = useAsset()
 
-  const [lastBlock, setLastBlock] = useState(0)
+  const [lastBlock, setLastBlock] = useState<number>(0)
+  const [priceHistory, setPriceHistory] = useState([])
+  const [liquidityHistory, setLiquidityHistory] = useState([])
+  const [timestamps, setTimestamps] = useState([])
   const [isLoading, setIsLoading] = useState(true)
   const [graphData, setGraphData] = useState<ChartData>()
 
@@ -142,25 +145,36 @@ export default function Graph(): ReactElement {
   }, [locale, darkMode.value])
 
   useEffect(() => {
-    if (!data || data.poolTransactions.length === 0) return
+    if (!data) return
     Logger.log('Fired GraphData!')
 
     const latestTimestamps = [
+      ...timestamps,
       ...data.poolTransactions.map((item) => {
         const date = new Date(item.timestamp * 1000)
         return `${date.toLocaleDateString()} ${date.toLocaleTimeString()}`
       })
     ]
+    setTimestamps(latestTimestamps)
 
     const latestLiquidtyHistory = [
+      ...liquidityHistory,
       ...data.poolTransactions.map((item) => item.oceanReserve)
     ]
 
+    setLiquidityHistory(latestLiquidtyHistory)
+
     const latestPriceHistory = [
+      ...priceHistory,
       ...data.poolTransactions.map((item) => item.spotPrice)
     ]
 
-    if (data.poolTransactions.length < 0) {
+    setPriceHistory(latestPriceHistory)
+
+    if (data.poolTransactions.length > 0) {
+      const newBlock =
+        data.poolTransactions[data.poolTransactions.length - 1].block
+      if (newBlock === lastBlock) return
       setLastBlock(
         data.poolTransactions[data.poolTransactions.length - 1].block
       )

--- a/src/components/organisms/AssetActions/Pool/Graph.tsx
+++ b/src/components/organisms/AssetActions/Pool/Graph.tsx
@@ -124,10 +124,6 @@ export default function Graph(): ReactElement {
   const { price } = useAsset()
 
   const [lastBlock, setLastBlock] = useState(0)
-  const [priceHistory, setPriceHistory] = useState([])
-  const [liquidityHistory, setLiquidityHistory] = useState([])
-  const [timestamps, setTimestamps] = useState([])
-
   const [isLoading, setIsLoading] = useState(true)
   const [graphData, setGraphData] = useState<ChartData>()
 
@@ -156,18 +152,13 @@ export default function Graph(): ReactElement {
       })
     ]
 
-    setTimestamps(latestTimestamps)
-
     const latestLiquidtyHistory = [
       ...data.poolTransactions.map((item) => item.oceanReserve)
     ]
 
-    setLiquidityHistory(latestLiquidtyHistory)
-
     const latestPriceHistory = [
       ...data.poolTransactions.map((item) => item.spotPrice)
     ]
-    setPriceHistory(latestPriceHistory)
 
     if (data.poolTransactions.length < 0) {
       setLastBlock(


### PR DESCRIPTION
Fixes #691.

Changes proposed in this PR:

- Fix pool statistics show the same statistics graphic twice when switching tabs