### PR TITLE
add fileinfo fetching

### DIFF
--- a/src/components/organisms/AssetActions/index.tsx
+++ b/src/components/organisms/AssetActions/index.tsx
@@ -11,7 +11,7 @@ import Trade from './Trade'
 import { useAsset } from '../../../providers/Asset'
 import { useOcean } from '../../../providers/Ocean'
 import { useWeb3 } from '../../../providers/Web3'
-import { fileinfo, getFileInfo } from '../../../utils/provider'
+import { getFileInfo } from '../../../utils/provider'
 import axios from 'axios'
 
 export default function AssetActions(): ReactElement {
@@ -26,28 +26,30 @@ export default function AssetActions(): ReactElement {
   const isCompute = Boolean(ddo?.findServiceByType('compute'))
 
   useEffect(() => {
-    const { attributes } = ddo.findServiceByType('metadata')
-    setFileMetadata(attributes.main.files[0])
-    // !!!!!  do not remove this, we will enable this again after fileInfo endpoint is fixed !!!
-    // if (!config) return
-    // const source = axios.CancelToken.source()
-    // async function initFileInfo() {
-    //   setFileIsLoading(true)
-    //   try {
-    //     const fileInfo = await getFileInfo(
-    //       DID.parse(`${ddo.id}`),
-    //       config.providerUri,
-    //       source.token
-    //     )
-    //     setFileMetadata(fileInfo.data[0])
-    //   } catch (error) {
-    //     Logger.error(error.message)
-    //   } finally {
-    //     setFileIsLoading(false)
-    //   }
-    // }
-    // initFileInfo()
-  }, [config, ddo.id])
+    if (!config) return
+    const source = axios.CancelToken.source()
+    async function initFileInfo() {
+      setFileIsLoading(true)
+      try {
+        const fileInfo = await getFileInfo(
+          DID.parse(`${ddo.id}`),
+          config.providerUri,
+          source.token
+        )
+
+        setFileMetadata(fileInfo.data[0])
+      } catch (error) {
+        Logger.error(error.message)
+      } finally {
+        // this triggers a memory leak warrning, no idea how to fix
+        setFileIsLoading(false)
+      }
+    }
+    initFileInfo()
+    return () => {
+      source.cancel()
+    }
+  }, [config, ddo])
 
   // Get and set user DT balance
   useEffect(() => {


### PR DESCRIPTION
Reintroduce file info fetching from provider. Can be tested on rinkeby

ToDo

- [x] Provider release and deployments are not done