### PR TITLE
Fix refetch data token orders

### DIFF
--- a/src/components/pages/History/ComputeJobs/index.tsx
+++ b/src/components/pages/History/ComputeJobs/index.tsx
@@ -109,14 +109,12 @@ export default function ComputeJobs(): ReactElement {
     }
   })
 
-  console.log(data)
-
   async function getJobs() {
     if (!ocean || !account) return
 
     setIsLoading(true)
 
-    // await refetch()
+    await refetch()
     const dtList = []
     const computeJobs: ComputeJobMetaData[] = []
     for (let i = 0; i < data.tokenOrders.length; i++) {

--- a/src/components/pages/History/ComputeJobs/index.tsx
+++ b/src/components/pages/History/ComputeJobs/index.tsx
@@ -60,7 +60,11 @@ const columns = [
   {
     name: 'Finished',
     selector: function getTimeRow(row: ComputeJobMetaData) {
-      return <Time date={row.dateFinished} isUnix relative />
+      return row.dateFinished ? (
+        <Time date={row.dateFinished} isUnix relative />
+      ) : (
+        ''
+      )
     }
   },
   {
@@ -111,6 +115,8 @@ export default function ComputeJobs(): ReactElement {
 
   async function getJobs() {
     if (!ocean || !account) return
+
+    console.log('get jobs')
 
     setIsLoading(true)
 

--- a/src/components/pages/History/ComputeJobs/index.tsx
+++ b/src/components/pages/History/ComputeJobs/index.tsx
@@ -116,8 +116,6 @@ export default function ComputeJobs(): ReactElement {
   async function getJobs() {
     if (!ocean || !account) return
 
-    console.log('get jobs')
-
     setIsLoading(true)
 
     await refetch()

--- a/src/components/pages/History/ComputeJobs/index.tsx
+++ b/src/components/pages/History/ComputeJobs/index.tsx
@@ -103,17 +103,20 @@ export default function ComputeJobs(): ReactElement {
   const { accountId } = useWeb3()
   const [isLoading, setIsLoading] = useState(true)
   const [jobs, setJobs] = useState<ComputeJobMetaData[]>([])
-  const { data } = useQuery<ComputeOrders>(getComputeOrders, {
+  const { data, refetch } = useQuery<ComputeOrders>(getComputeOrders, {
     variables: {
       user: accountId?.toLowerCase()
     }
   })
+
+  console.log(data)
 
   async function getJobs() {
     if (!ocean || !account) return
 
     setIsLoading(true)
 
+    // await refetch()
     const dtList = []
     const computeJobs: ComputeJobMetaData[] = []
     for (let i = 0; i < data.tokenOrders.length; i++) {


### PR DESCRIPTION
Fixes #683 .

Changes proposed in this PR:

- Refetch the token orders when getJobs function is called