### PR TITLE
Fix datasets algorithm is allowed to run on returns nothing

### DIFF
--- a/src/components/organisms/AssetContent/AlgorithmDatasetsListForCompute.tsx
+++ b/src/components/organisms/AssetContent/AlgorithmDatasetsListForCompute.tsx
@@ -21,7 +21,10 @@ export default function AlgorithmDatasetsListForCompute({
 
   useEffect(() => {
     async function getDatasetsAllowedForCompute() {
-      const datasetComputeService = dataset.findServiceByType('compute')
+      const isCompute = Boolean(dataset?.findServiceByType('compute'))
+      const datasetComputeService = dataset.findServiceByType(
+        isCompute ? 'compute' : 'access'
+      )
       const datasets = await getAlgorithmDatasetsForCompute(
         algorithmDid,
         datasetComputeService?.serviceEndpoint,


### PR DESCRIPTION
Fixes #730 .

Changes proposed in this PR:

- Fix datasets algorithm is allowed to run on returns nothing