### PR TITLE
bump ocean.js to v0.16.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@coingecko/cryptoformat": "^0.4.2",
         "@loadable/component": "^5.15.0",
         "@oceanprotocol/art": "^3.0.0",
-        "@oceanprotocol/lib": "^0.16.5",
+        "@oceanprotocol/lib": "^0.16.6",
         "@oceanprotocol/typographies": "^0.1.0",
         "@portis/web3": "^4.0.4",
         "@sindresorhus/slugify": "^2.1.0",
@@ -4948,9 +4948,9 @@
       }
     },
     "node_modules/@oceanprotocol/lib": {
-      "version": "0.16.5",
-      "resolved": "https://registry.npmjs.org/@oceanprotocol/lib/-/lib-0.16.5.tgz",
-      "integrity": "sha512-7L0BgKqLc7w9GjV8K17t3J2rAmh8UiOQuHG2C4EmuDre/tBhRRZxSCQpDYEsADuEQGTx0JkyLWzrI3dMy8e1Dw==",
+      "version": "0.16.6",
+      "resolved": "https://registry.npmjs.org/@oceanprotocol/lib/-/lib-0.16.6.tgz",
+      "integrity": "sha512-ycjiIvWs6cjbfnkJgQ9V/hghViAh1vepxE9p/9wg/wZDFMsXRfLzLFWcrF6CQ0Ce8khZhErdBBzaCfyq1gfVyg==",
       "dependencies": {
         "@ethereum-navigator/navigator": "^0.5.3",
         "@oceanprotocol/contracts": "^0.6.5",
@@ -58433,9 +58433,9 @@
       }
     },
     "@oceanprotocol/lib": {
-      "version": "0.16.5",
-      "resolved": "https://registry.npmjs.org/@oceanprotocol/lib/-/lib-0.16.5.tgz",
-      "integrity": "sha512-7L0BgKqLc7w9GjV8K17t3J2rAmh8UiOQuHG2C4EmuDre/tBhRRZxSCQpDYEsADuEQGTx0JkyLWzrI3dMy8e1Dw==",
+      "version": "0.16.6",
+      "resolved": "https://registry.npmjs.org/@oceanprotocol/lib/-/lib-0.16.6.tgz",
+      "integrity": "sha512-ycjiIvWs6cjbfnkJgQ9V/hghViAh1vepxE9p/9wg/wZDFMsXRfLzLFWcrF6CQ0Ce8khZhErdBBzaCfyq1gfVyg==",
       "requires": {
         "@ethereum-navigator/navigator": "^0.5.3",
         "@oceanprotocol/contracts": "^0.6.5",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@coingecko/cryptoformat": "^0.4.2",
     "@loadable/component": "^5.15.0",
     "@oceanprotocol/art": "^3.0.0",
-    "@oceanprotocol/lib": "^0.16.5",
+    "@oceanprotocol/lib": "^0.16.6",
     "@oceanprotocol/typographies": "^0.1.0",
     "@portis/web3": "^4.0.4",
     "@sindresorhus/slugify": "^2.1.0",


### PR DESCRIPTION
bump ocean.js to [v0.16.6](https://github.com/oceanprotocol/ocean.js/releases/tag/v0.16.6). Might fix an issue the Raven Protocol people are running into.