### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @mihaisc @kremalicious
+* @mihaisc @kremalicious @claudiaHash @bogdanfazakas @KatunaNorbert @jamiehewitt15 @DimitarSD


### PR DESCRIPTION
We all own the code by now 😀

We require approval by code owners on each PR so with this change everybody in this list is requested for review automatically on each PR ready for review. 

And with that, we can also think about bumping the requirement from 1 code owner to 2 code owner approvals for each PR as more eyes on each change are always preferable 