### PR TITLE
Hiding error message

### DIFF
--- a/src/components/molecules/MetadataFeedback.tsx
+++ b/src/components/molecules/MetadataFeedback.tsx
@@ -1,7 +1,7 @@
 import Alert from '../atoms/Alert'
 import Button from '../atoms/Button'
 import Loader from '../atoms/Loader'
-import React, { ReactElement } from 'react'
+import React, { ReactElement, useState, FormEvent } from 'react'
 import styles from './MetadataFeedback.module.css'
 import SuccessConfetti from '../atoms/SuccessConfetti'
 
@@ -55,13 +55,24 @@ export default function MetadataFeedback({
   successAction: Action
   setError: (error: string) => void
 }): ReactElement {
+  const [moreInfo, setMoreInfo] = useState<boolean>(false)
+
+  function toggleMoreInfo(e: FormEvent<Element>) {
+    e.preventDefault()
+    moreInfo === true ? setMoreInfo(false) : setMoreInfo(true)
+  }
+
   return (
     <div className={styles.feedback}>
       <div className={styles.box}>
         <h3>{title}</h3>
         {error ? (
           <>
-            <Alert text={error} state="error" />
+            <p>Sorry, something went wrong. Please try again.</p>
+            {moreInfo && <Alert text={error} state="error" />}
+            <Button style="text" size="small" onClick={toggleMoreInfo}>
+              {moreInfo === false ? 'More Info' : 'Hide error'}
+            </Button>
             <ActionError setError={setError} />
           </>
         ) : success ? (


### PR DESCRIPTION
Closes: #714 

Changes proposed in this PR:
- Publishing error messages are hidden by default
- User must click "More Info" to see the error message 

## To Test
The easiest way to test this is to publish an asset and then reject the metamask transactions.

The default view is with the error message hidden:
![Hidden error](https://user-images.githubusercontent.com/20739535/127165123-3668a966-1e1f-484d-bc37-544a22946ba5.png)

If you click "More Info" the error message shows:
![Show error - 2021-07-27_16-40](https://user-images.githubusercontent.com/20739535/127165159-991ed7cf-9a36-44ba-afc5-aa19bcc18a95.png)

