### PR TITLE
Fixing more info button padding

### DIFF
--- a/src/components/molecules/MetadataFeedback.module.css
+++ b/src/components/molecules/MetadataFeedback.module.css
@@ -38,3 +38,6 @@
 .action {
   margin-top: calc(var(--spacer) / 1.5);
 }
+.moreInfo {
+  padding: calc(var(--spacer) / 4) calc(var(--spacer) / 2) !important;
+}

--- a/src/components/molecules/MetadataFeedback.tsx
+++ b/src/components/molecules/MetadataFeedback.tsx
@@ -70,7 +70,12 @@ export default function MetadataFeedback({
           <>
             <p>Sorry, something went wrong. Please try again.</p>
             {moreInfo && <Alert text={error} state="error" />}
-            <Button style="text" size="small" onClick={toggleMoreInfo}>
+            <Button
+              style="text"
+              size="small"
+              onClick={toggleMoreInfo}
+              className={styles.moreInfo}
+            >
               {moreInfo === false ? 'More Info' : 'Hide error'}
             </Button>
             <ActionError setError={setError} />


### PR DESCRIPTION
Closes: #782 

Changes proposed in this PR:
- Adding additional padding around the "More Info" text button.

Before it looked like this: 
![Buttons too close](https://user-images.githubusercontent.com/20739535/128729069-d1115a91-77d4-4420-b96b-c19870ed3700.png)

Now it looks like this:
![fixed button spacing](https://user-images.githubusercontent.com/20739535/128729020-3d106b49-b2a1-4a1f-9c47-99c285323c63.png)
