### PR TITLE
Fix metadata history

### DIFF
--- a/src/components/organisms/AssetContent/EditHistory.tsx
+++ b/src/components/organisms/AssetContent/EditHistory.tsx
@@ -20,7 +20,6 @@ const getReceipts = gql`
 `
 
 export default function EditHistory(): ReactElement {
-  const { networkId } = useWeb3()
   const { ddo } = useAsset()
   const [result] = useQuery({
     query: getReceipts,

--- a/src/components/organisms/AssetContent/EditHistory.tsx
+++ b/src/components/organisms/AssetContent/EditHistory.tsx
@@ -5,7 +5,6 @@ import Time from '../../atoms/Time'
 import styles from './EditHistory.module.css'
 import { gql, useQuery } from 'urql'
 import { ReceiptData_datatokens_updates as ReceiptData } from '../../../@types/apollo/ReceiptData'
-import { useWeb3 } from '../../../providers/Web3'
 
 const getReceipts = gql`
   query ReceiptData($address: ID!) {

--- a/src/components/organisms/AssetContent/EditHistory.tsx
+++ b/src/components/organisms/AssetContent/EditHistory.tsx
@@ -27,14 +27,9 @@ export default function EditHistory(): ReactElement {
   const { data } = result
 
   const [receipts, setReceipts] = useState<ReceiptData[]>()
-  const [creationTx, setCreationTx] = useState<string>()
 
   useEffect(() => {
     if (!data || data.datatokens.length === 0) return
-
-    const receiptCollectionLength = data.datatokens[0].updates.length
-    const creationData = data.datatokens[0].updates[receiptCollectionLength - 1]
-    setCreationTx(creationData.tx)
 
     const receiptCollection = [...data.datatokens[0].updates]
     receiptCollection.splice(-1, 1)
@@ -55,7 +50,7 @@ export default function EditHistory(): ReactElement {
           </li>
         ))}
         <li className={styles.item}>
-          <ExplorerLink networkId={ddo.chainId} path={`/tx/${creationTx}`}>
+          <ExplorerLink networkId={ddo.chainId} path={`/tx/${ddo.event.txid}`}>
             published <Time date={ddo.created} relative />
           </ExplorerLink>
         </li>


### PR DESCRIPTION
Closes: https://github.com/oceanprotocol/market/issues/773

Changes proposed in this PR:
- Getting the transaction Id from the DDO rather than using the graphQL query
- Removing unused `networkId` 