### PR TITLE
Display user's pool transactions history values

### DIFF
--- a/src/components/molecules/PoolTransactions/index.tsx
+++ b/src/components/molecules/PoolTransactions/index.tsx
@@ -129,9 +129,11 @@ const columnsMinimal = [columns[0], columns[3]]
 
 export default function PoolTransactions({
   poolAddress,
+  poolChainId,
   minimal
 }: {
   poolAddress?: string
+  poolChainId?: number[]
   minimal?: boolean
 }): ReactElement {
   const { accountId } = useWeb3()
@@ -143,13 +145,17 @@ export default function PoolTransactions({
   const [data, setData] = useState<PoolTransaction[]>()
 
   async function fetchPoolTransactionData() {
-    const variables = { user: accountId?.toLowerCase() }
+    const variables = {
+      user: accountId?.toLowerCase(),
+      pool: poolAddress?.toLowerCase()
+    }
     const transactions: PoolTransaction[] = []
     const result = await fetchDataForMultipleChains(
       poolAddress ? txHistoryQueryByPool : txHistoryQuery,
       variables,
-      chainIds
+      poolAddress ? poolChainId : chainIds
     )
+
     for (let i = 0; i < result.length; i++) {
       result[i].poolTransactions.forEach((poolTransaction: PoolTransaction) => {
         transactions.push(poolTransaction)

--- a/src/components/organisms/AssetActions/Pool/index.tsx
+++ b/src/components/organisms/AssetActions/Pool/index.tsx
@@ -386,7 +386,11 @@ export default function Pool(): ReactElement {
 
           {accountId && (
             <AssetActionHistoryTable title="Your Pool Transactions">
-              <PoolTransactions poolAddress={price?.address} minimal />
+              <PoolTransactions
+                poolAddress={price?.address}
+                poolChainId={[ddo.chainId]}
+                minimal
+              />
             </AssetActionHistoryTable>
           )}
         </>


### PR DESCRIPTION
Fixes #772  .

Changes proposed in this PR:

- displaying user's pool transaction history values fixed
- query only the subgraph corresponding to the asset's network 
