### PR TITLE
fix checkIsConsumable dependencies

### DIFF
--- a/src/components/organisms/AssetActions/index.tsx
+++ b/src/components/organisms/AssetActions/index.tsx
@@ -30,9 +30,10 @@ export default function AssetActions(): ReactElement {
   const [consumableFeedback, setConsumableFeedback] = useState<string>('')
 
   useEffect(() => {
-    if (!ddo || !accountId) return
+    if (!ddo || !accountId || !ocean || !isAssetNetwork) return
+
     async function checkIsConsumable() {
-      const consumable: any = await ocean.assets.isConsumable(
+      const consumable = await ocean.assets.isConsumable(
         ddo,
         accountId.toLowerCase()
       )
@@ -42,11 +43,13 @@ export default function AssetActions(): ReactElement {
       }
     }
     checkIsConsumable()
-  }, [accountId, ddo])
+  }, [accountId, isAssetNetwork, ddo, ocean])
 
   useEffect(() => {
     if (!config) return
+
     const source = axios.CancelToken.source()
+
     async function initFileInfo() {
       setFileIsLoading(true)
       try {
@@ -60,11 +63,12 @@ export default function AssetActions(): ReactElement {
       } catch (error) {
         Logger.error(error.message)
       } finally {
-        // this triggers a memory leak warrning, no idea how to fix
+        // this triggers a memory leak warning, no idea how to fix
         setFileIsLoading(false)
       }
     }
     initFileInfo()
+
     return () => {
       source.cancel()
     }


### PR DESCRIPTION
- fixes #787
- do nothing when `ocean` is not present, or when asset network is not the same as user network as this would give us a wrong `ocean` to work with, making the check fail