### PR TITLE
Remove 'Forever' timeout on edit compute dataset

### DIFF
--- a/src/components/organisms/AssetActions/Edit/FormEditMetadata.tsx
+++ b/src/components/organisms/AssetActions/Edit/FormEditMetadata.tsx
@@ -12,8 +12,6 @@ function handleTimeoutCustomOption(
   data: FormFieldProps[],
   values: Partial<MetadataPublishFormDataset>
 ) {
-  console.log('DATA: ', data)
-  console.log('VALUES: ', values)
   const timeoutFieldContent = data.filter(
     (field) => field.name === 'timeout'
   )[0]
@@ -43,9 +41,6 @@ function handleTimeoutCustomOption(
     data[timeoutInputIndex].options[5] = values.timeout
   }
 }
-
-const computeDatasetTimeout = ['1 day', '1 week', '1 month', '1 year']
-
 export default function FormEditMetadata({
   data,
   setShowEdit,
@@ -66,7 +61,7 @@ export default function FormEditMetadata({
     validateField,
     setFieldValue
   }: FormikContextType<Partial<MetadataPublishFormDataset>> = useFormikContext()
-  console.log('DATA: ', data)
+
   // Manually handle change events instead of using `handleChange` from Formik.
   // Workaround for default `validateOnChange` not kicking in
   function handleFieldChange(
@@ -76,11 +71,21 @@ export default function FormEditMetadata({
     validateField(field.name)
     setFieldValue(field.name, e.target.value)
   }
-
   // This component is handled by Formik so it's not rendered like a "normal" react component,
   // so handleTimeoutCustomOption is called only once.
   // https://github.com/oceanprotocol/market/pull/324#discussion_r561132310
   if (data && values) handleTimeoutCustomOption(data, values)
+
+  const timeoutOptionsArray = data.filter(
+    (field) => field.name === 'timeout'
+  )[0].options
+
+  if (isComputeDataset && timeoutOptionsArray.includes('Forever')) {
+    const foreverOptionIndex = timeoutOptionsArray.indexOf('Forever')
+    timeoutOptionsArray.splice(foreverOptionIndex, 1)
+  } else if (!isComputeDataset && !timeoutOptionsArray.includes('Forever')) {
+    timeoutOptionsArray.push('Forever')
+  }
 
   return (
     <Form className={styles.form}>
@@ -89,12 +94,12 @@ export default function FormEditMetadata({
           (!showPrice && field.name === 'price') || (
             <Field
               key={field.name}
-              {...field}
               options={
-                field.name === 'timeout' && isComputeDataset
-                  ? computeDatasetTimeout
+                field.name === 'timeout' && isComputeDataset === true
+                  ? timeoutOptionsArray
                   : field.options
               }
+              {...field}
               component={Input}
               prefix={field.name === 'price' && config.oceanTokenSymbol}
               onChange={(e: ChangeEvent<HTMLInputElement>) =>

--- a/src/components/organisms/AssetActions/Edit/FormEditMetadata.tsx
+++ b/src/components/organisms/AssetActions/Edit/FormEditMetadata.tsx
@@ -12,6 +12,8 @@ function handleTimeoutCustomOption(
   data: FormFieldProps[],
   values: Partial<MetadataPublishFormDataset>
 ) {
+  console.log('DATA: ', data)
+  console.log('VALUES: ', values)
   const timeoutFieldContent = data.filter(
     (field) => field.name === 'timeout'
   )[0]
@@ -42,25 +44,29 @@ function handleTimeoutCustomOption(
   }
 }
 
+const computeDatasetTimeout = ['1 day', '1 week', '1 month', '1 year']
+
 export default function FormEditMetadata({
   data,
   setShowEdit,
   setTimeoutStringValue,
   values,
-  showPrice
+  showPrice,
+  isComputeDataset
 }: {
   data: FormFieldProps[]
   setShowEdit: (show: boolean) => void
   setTimeoutStringValue: (value: string) => void
   values: Partial<MetadataPublishFormDataset>
   showPrice: boolean
+  isComputeDataset: boolean
 }): ReactElement {
   const { config } = useOcean()
   const {
     validateField,
     setFieldValue
   }: FormikContextType<Partial<MetadataPublishFormDataset>> = useFormikContext()
-
+  console.log('DATA: ', data)
   // Manually handle change events instead of using `handleChange` from Formik.
   // Workaround for default `validateOnChange` not kicking in
   function handleFieldChange(
@@ -84,6 +90,11 @@ export default function FormEditMetadata({
             <Field
               key={field.name}
               {...field}
+              options={
+                field.name === 'timeout' && isComputeDataset
+                  ? computeDatasetTimeout
+                  : field.options
+              }
               component={Input}
               prefix={field.name === 'price' && config.oceanTokenSymbol}
               onChange={(e: ChangeEvent<HTMLInputElement>) =>

--- a/src/components/organisms/AssetActions/Edit/index.tsx
+++ b/src/components/organisms/AssetActions/Edit/index.tsx
@@ -55,9 +55,11 @@ const contentQuery = graphql`
 `
 
 export default function Edit({
-  setShowEdit
+  setShowEdit,
+  isComputeType
 }: {
   setShowEdit: (show: boolean) => void
+  isComputeType?: boolean
 }): ReactElement {
   const data = useStaticQuery(contentQuery)
   const content = data.content.edges[0].node.childPagesJson
@@ -201,6 +203,7 @@ export default function Edit({
                 setTimeoutStringValue={setTimeoutStringValue}
                 values={initialValues}
                 showPrice={price.type === 'exchange'}
+                isComputeDataset={isComputeType}
               />
 
               <aside>

--- a/src/components/organisms/AssetContent/index.tsx
+++ b/src/components/organisms/AssetContent/index.tsx
@@ -50,6 +50,7 @@ export default function AssetContent(props: AssetContentProps): ReactElement {
   const { owner, isInPurgatory, purgatoryData, isAssetNetwork } = useAsset()
   const [showPricing, setShowPricing] = useState(false)
   const [showEdit, setShowEdit] = useState<boolean>()
+  const [isComputeType, setIsComputeType] = useState<boolean>(false)
   const [showEditCompute, setShowEditCompute] = useState<boolean>()
   const [showEditAdvancedSettings, setShowEditAdvancedSettings] =
     useState<boolean>()
@@ -63,7 +64,8 @@ export default function AssetContent(props: AssetContentProps): ReactElement {
     const isOwner = accountId.toLowerCase() === owner.toLowerCase()
     setIsOwner(isOwner)
     setShowPricing(isOwner && price.type === '')
-  }, [accountId, price, owner])
+    setIsComputeType(Boolean(ddo.findServiceByType('compute')))
+  }, [accountId, price, owner, ddo])
 
   function handleEditButton() {
     // move user's focus to top of screen
@@ -82,7 +84,7 @@ export default function AssetContent(props: AssetContentProps): ReactElement {
   }
 
   return showEdit ? (
-    <Edit setShowEdit={setShowEdit} />
+    <Edit setShowEdit={setShowEdit} isComputeType={isComputeType} />
   ) : showEditCompute ? (
     <EditComputeDataset setShowEdit={setShowEditCompute} />
   ) : showEditAdvancedSettings ? (


### PR DESCRIPTION
Fixes #789 .

Changes proposed in this PR:

- 'Forever'  removed from timeout options on edit compute dataset 
