### PR TITLE
Display the same string for timeout set to '1 month'

### DIFF
--- a/src/models/FormEditMetadata.ts
+++ b/src/models/FormEditMetadata.ts
@@ -1,5 +1,5 @@
 import { MetadataMarket, MetadataEditForm } from '../@types/MetaData'
-import { secondsToString } from '../utils/metadata'
+import { mapTimeoutSecondsToString } from '../utils/metadata'
 import { EditableMetadataLinks } from '@oceanprotocol/lib'
 import * as Yup from 'yup'
 
@@ -24,7 +24,7 @@ export function getInitialValues(
     description: metadata.additionalInformation.description,
     price,
     links: metadata.additionalInformation.links,
-    timeout: secondsToString(timeout),
+    timeout: mapTimeoutSecondsToString(timeout),
     author: metadata.main.author
   }
 }

--- a/src/models/FormEditMetadata.ts
+++ b/src/models/FormEditMetadata.ts
@@ -1,5 +1,5 @@
 import { MetadataMarket, MetadataEditForm } from '../@types/MetaData'
-import { mapTimeoutSecondsToString } from '../utils/metadata'
+import { secondsToString } from '../utils/metadata'
 import { EditableMetadataLinks } from '@oceanprotocol/lib'
 import * as Yup from 'yup'
 
@@ -24,7 +24,7 @@ export function getInitialValues(
     description: metadata.additionalInformation.description,
     price,
     links: metadata.additionalInformation.links,
-    timeout: mapTimeoutSecondsToString(timeout),
+    timeout: secondsToString(timeout),
     author: metadata.main.author
   }
 }

--- a/src/utils/metadata.ts
+++ b/src/utils/metadata.ts
@@ -34,23 +34,6 @@ export function mapTimeoutStringToSeconds(timeout: string): number {
   }
 }
 
-export function mapTimeoutSecondsToString(timeout: number): string {
-  switch (timeout) {
-    case 0:
-      return 'Forever'
-    case 86400:
-      return '1 day'
-    case 604800:
-      return '1 week'
-    case 2630000:
-      return '1 month'
-    case 31556952:
-      return '1 year'
-    default:
-      return 'Forever'
-  }
-}
-
 function numberEnding(number: number): string {
   return number > 1 ? 's' : ''
 }
@@ -59,6 +42,7 @@ export function secondsToString(numberOfSeconds: number): string {
   if (numberOfSeconds === 0) return 'Forever'
 
   const years = Math.floor(numberOfSeconds / 31536000)
+  const months = Math.floor((numberOfSeconds %= 31536000) / 2630000)
   const weeks = Math.floor((numberOfSeconds %= 31536000) / 604800)
   const days = Math.floor((numberOfSeconds %= 604800) / 86400)
   const hours = Math.floor((numberOfSeconds %= 86400) / 3600)
@@ -67,6 +51,8 @@ export function secondsToString(numberOfSeconds: number): string {
 
   return years
     ? `${years} year${numberEnding(years)}`
+    : months
+    ? `${months} month${numberEnding(months)}`
     : weeks
     ? `${weeks} week${numberEnding(weeks)}`
     : days

--- a/src/utils/metadata.ts
+++ b/src/utils/metadata.ts
@@ -34,6 +34,23 @@ export function mapTimeoutStringToSeconds(timeout: string): number {
   }
 }
 
+export function mapTimeoutSecondsToString(timeout: number): string {
+  switch (timeout) {
+    case 0:
+      return 'Forever'
+    case 86400:
+      return '1 day'
+    case 604800:
+      return '1 week'
+    case 2630000:
+      return '1 month'
+    case 31556952:
+      return '1 year'
+    default:
+      return 'Forever'
+  }
+}
+
 function numberEnding(number: number): string {
   return number > 1 ? 's' : ''
 }


### PR DESCRIPTION
Fixes #797  .

Changes proposed in this PR:

- display the same string for timeout set to '1 month' on edit options and metadata preview