### PR TITLE
Display highest liquidity assets fix

### DIFF
--- a/src/components/pages/Home.tsx
+++ b/src/components/pages/Home.tsx
@@ -94,8 +94,6 @@ function SectionQueryResult({
         try {
           setLoading(true)
           const result = await queryMetadata(query, source.token)
-          console.log('QUERY: ', query)
-          console.log('RESULT: ', result.results)
           if (queryData && result.totalResults > 0) {
             const searchDIDs = queryData.split(' ')
             const sortedAssets = sortElements(result.results, searchDIDs)

--- a/src/components/pages/Home.tsx
+++ b/src/components/pages/Home.tsx
@@ -104,7 +104,7 @@ function SectionQueryResult({
           setResult(result)
           setLoading(false)
         } catch (error) {
-          Logger.log(error.message)
+          Logger.error(error.message)
         }
       }
     }

--- a/src/components/pages/Home.tsx
+++ b/src/components/pages/Home.tsx
@@ -21,10 +21,10 @@ import styles from './Home.module.css'
 async function getQueryHighest(
   chainIds: number[]
 ): Promise<[SearchQuery, string]> {
-  const dids = await getHighestLiquidityDIDs(chainIds)
+  const [dids, didsLength] = await getHighestLiquidityDIDs(chainIds)
   const queryHighest = {
     page: 1,
-    offset: dids.length,
+    offset: didsLength,
     query: {
       query_string: {
         query: `(${dids}) AND (${transformChainIdsListToQuery(
@@ -72,6 +72,7 @@ function SectionQueryResult({
   queryData?: string
 }) {
   const { appConfig } = useSiteMetadata()
+  const { chainIds } = useUserPreferences()
   const [result, setResult] = useState<QueryResult>()
   const [loading, setLoading] = useState<boolean>()
 
@@ -80,20 +81,33 @@ function SectionQueryResult({
     const source = axios.CancelToken.source()
 
     async function init() {
-      try {
-        setLoading(true)
-        const result = await queryMetadata(query, source.token)
-        if (queryData && result.totalResults > 0) {
-          const searchDIDs = queryData.split(' ')
-          const sortedAssets = sortElements(result.results, searchDIDs)
-          const overflow = sortedAssets.length - 9
-          sortedAssets.splice(sortedAssets.length - overflow, overflow)
-          result.results = sortedAssets
+      if (chainIds.length === 0) {
+        const result: QueryResult = {
+          results: [],
+          page: 0,
+          totalPages: 0,
+          totalResults: 0
         }
         setResult(result)
         setLoading(false)
-      } catch (error) {
-        Logger.log(error.message)
+      } else {
+        try {
+          setLoading(true)
+          const result = await queryMetadata(query, source.token)
+          console.log('QUERY: ', query)
+          console.log('RESULT: ', result.results)
+          if (queryData && result.totalResults > 0) {
+            const searchDIDs = queryData.split(' ')
+            const sortedAssets = sortElements(result.results, searchDIDs)
+            const overflow = sortedAssets.length - 9
+            sortedAssets.splice(sortedAssets.length - overflow, overflow)
+            result.results = sortedAssets
+          }
+          setResult(result)
+          setLoading(false)
+        } catch (error) {
+          Logger.log(error.message)
+        }
       }
     }
     init()

--- a/src/utils/subgraph.ts
+++ b/src/utils/subgraph.ts
@@ -151,7 +151,7 @@ export function getQueryContext(chainId: number): OperationContext {
     url: `${getSubgraphUri(
       Number(chainId)
     )}/subgraphs/name/oceanprotocol/ocean-subgraph`,
-    requestPolicy: 'network-only'
+    requestPolicy: 'cache-and-network'
   }
 
   return queryContext

--- a/src/utils/subgraph.ts
+++ b/src/utils/subgraph.ts
@@ -151,7 +151,7 @@ export function getQueryContext(chainId: number): OperationContext {
     url: `${getSubgraphUri(
       Number(chainId)
     )}/subgraphs/name/oceanprotocol/ocean-subgraph`,
-    requestPolicy: 'cache-first'
+    requestPolicy: 'network-only'
   }
 
   return queryContext

--- a/src/utils/subgraph.ts
+++ b/src/utils/subgraph.ts
@@ -469,7 +469,7 @@ export async function getAssetsBestPrices(
 
 export async function getHighestLiquidityDIDs(
   chainIds: number[]
-): Promise<string> {
+): Promise<[string, number]> {
   const didList: string[] = []
   let highestLiquidiyAssets: HighestLiquidityAssetsPools[] = []
   for (const chain of chainIds) {
@@ -495,5 +495,5 @@ export async function getHighestLiquidityDIDs(
     .replace(/"/g, '')
     .replace(/(\[|\])/g, '')
     .replace(/(did:op:)/g, '0x')
-  return searchDids
+  return [searchDids, didList.length]
 }


### PR DESCRIPTION
Fixes #800.

Changes proposed in this PR:

- display highest liquidity assets according to selected network(s)
-  no network selected case fix
