### PR TITLE
Fix large description causes market to hang

### DIFF
--- a/src/components/molecules/AssetTeaser.tsx
+++ b/src/components/molecules/AssetTeaser.tsx
@@ -46,7 +46,10 @@ const AssetTeaser: React.FC<AssetTeaserProps> = ({
         <div className={styles.content}>
           <Dotdotdot tagName="p" clamp={3}>
             {removeMarkdown(
-              attributes?.additionalInformation?.description || ''
+              attributes?.additionalInformation?.description.substring(
+                0,
+                300
+              ) || ''
             )}
           </Dotdotdot>
         </div>


### PR DESCRIPTION
Fixes #775.

Changes proposed in this PR:

- Fix large description causes market to hang