### PR TITLE
Add service filters download and compute to the existing filters

### DIFF
--- a/src/components/templates/Search/filterService.module.css
+++ b/src/components/templates/Search/filterService.module.css
@@ -2,6 +2,13 @@
 div.filterList {
   white-space: normal;
   margin-bottom: 0;
+  display: flex;
+  flex-direction: row;
+  align-items: baseline;
+}
+
+.separator {
+  width: calc(var(--spacer) / 2);
 }
 
 .filter {

--- a/src/components/templates/Search/filterService.tsx
+++ b/src/components/templates/Search/filterService.tsx
@@ -56,7 +56,29 @@ export default function FilterPrice({
     navigate(urlLocation)
   }
 
+  async function applyFilter(filter: string, filterType: string) {
+    console.log('APPLY FILTER: ', filter, filterType)
+    let urlLocation = ''
+    if (filterType.localeCompare('accessType') === 0) {
+      console.log('IS ACCESS TYPE')
+      urlLocation = await addExistingParamsToUrl(location, ['accessType'])
+    } else {
+      console.log('IS SERVICE TYPE')
+      urlLocation = await addExistingParamsToUrl(location, ['serviceType'])
+    }
+
+    if (filter && location.search.indexOf(filterType) === -1) {
+      filterType === 'accessType'
+        ? (urlLocation = `${urlLocation}&accessType=${filter}`)
+        : (urlLocation = `${urlLocation}&serviceType=${filter}`)
+    }
+
+    filterType === 'accessType' ? setAccessType(filter) : setServiceType(filter)
+    navigate(urlLocation)
+  }
+
   async function handleSelectedFilter(isSelected: boolean, value: string) {
+    console.log('IS SELECTED, VALUE: ', isSelected, value)
     if (
       value === FilterByAccessOptions.Download ||
       value === FilterByAccessOptions.Compute
@@ -67,21 +89,21 @@ export default function FilterPrice({
           const otherValue = accessFilterItems.find(
             (p) => p.value !== value
           ).value
-          await applyAccessFilter(otherValue)
+          await applyFilter(otherValue, 'accessType')
           setAccessSelections([otherValue])
         } else {
           // only the current one selected -> deselect it
-          await applyAccessFilter(undefined)
+          await applyFilter(undefined, 'accessType')
           setAccessSelections([])
         }
       } else {
         if (accessSelections.length) {
           // one already selected -> both selected
-          await applyAccessFilter(undefined)
+          await applyFilter(undefined, 'accessType')
           setAccessSelections(accessFilterItems.map((p) => p.value))
         } else {
           // none selected -> select
-          await applyAccessFilter(value)
+          await applyFilter(value, 'accessType')
           setAccessSelections([value])
         }
       }
@@ -91,18 +113,18 @@ export default function FilterPrice({
           const otherValue = serviceFilterItems.find(
             (p) => p.value !== value
           ).value
-          await applyServiceFilter(otherValue)
+          await applyFilter(otherValue, 'serviceType')
           setServiceSelections([otherValue])
         } else {
-          await applyServiceFilter(undefined)
+          await applyFilter(undefined, 'serviceType')
           setServiceSelections([])
         }
       } else {
         if (serviceSelections.length) {
-          await applyServiceFilter(undefined)
+          await applyFilter(undefined, 'serviceType')
           setServiceSelections(serviceFilterItems.map((p) => p.value))
         } else {
-          await applyServiceFilter(value)
+          await applyFilter(value, 'serviceType')
           setServiceSelections([value])
         }
       }
@@ -148,6 +170,7 @@ export default function FilterPrice({
           </Button>
         )
       })}
+      &nbsp;&nbsp;&nbsp;
       {accessFilterItems.map((e, index) => {
         const isAccessSelected =
           e.value === accessType || accessSelections.includes(e.value)

--- a/src/components/templates/Search/filterService.tsx
+++ b/src/components/templates/Search/filterService.tsx
@@ -69,6 +69,7 @@ export default function FilterPrice({
           ).value
           console.log('VALUE both selected -> select the other one: ', value)
           await applyAccessFilter(otherValue)
+          setAccessSelections([otherValue])
         } else {
           // only the current one selected -> deselect it
           console.log('VALUE both selected -> select the other one: ', value)
@@ -78,7 +79,7 @@ export default function FilterPrice({
         if (accessSelections.length > 0) {
           // one already selected -> both selected
           console.log('VALUE one already selected -> both selected: ', value)
-          await applyAccessFilter(FilterByAccessOptions.All)
+          await applyAccessFilter(undefined)
           setAccessSelections(accessFilterItems.map((p) => p.value))
         } else {
           // none selected -> select
@@ -131,6 +132,7 @@ export default function FilterPrice({
       {serviceFilterItems.map((e, index) => {
         const isServiceSelected =
           e.value === serviceType || serviceSelections.includes(e.value)
+        console.log('IS SELECTED service: ', isServiceSelected)
         const selectFilter = cx({
           [styles.selected]: isServiceSelected,
           [styles.filter]: true
@@ -150,14 +152,10 @@ export default function FilterPrice({
         )
       })}
       {accessFilterItems.map((e, index) => {
-        console.log(
-          'ACCESS SELECTIONS: ',
-          accessSelections,
-          e.value,
-          accessSelections.includes(e.value)
-        )
         const isAccessSelected =
           e.value === accessType || accessSelections.includes(e.value)
+        console.log('IS SELECTED access: ', isAccessSelected, accessSelections)
+
         const selectFilter = cx({
           [styles.selected]: isAccessSelected,
           [styles.filter]: true
@@ -177,7 +175,8 @@ export default function FilterPrice({
         )
       })}
       {clearFilters.map((e, index) => {
-        const showClear = serviceSelections.length > 0
+        const showClear =
+          accessSelections.length > 0 || serviceSelections.length > 0
         return (
           <Button
             size="small"

--- a/src/components/templates/Search/filterService.tsx
+++ b/src/components/templates/Search/filterService.tsx
@@ -67,23 +67,20 @@ export default function FilterPrice({
           const otherValue = accessFilterItems.find(
             (p) => p.value !== value
           ).value
-          console.log('VALUE both selected -> select the other one: ', value)
           await applyAccessFilter(otherValue)
           setAccessSelections([otherValue])
         } else {
           // only the current one selected -> deselect it
-          console.log('VALUE both selected -> select the other one: ', value)
           await applyAccessFilter(undefined)
+          setAccessSelections([])
         }
       } else {
-        if (accessSelections.length > 0) {
+        if (accessSelections.length) {
           // one already selected -> both selected
-          console.log('VALUE one already selected -> both selected: ', value)
           await applyAccessFilter(undefined)
           setAccessSelections(accessFilterItems.map((p) => p.value))
         } else {
           // none selected -> select
-          console.log('VALUE none  selected -> select: ', value)
           await applyAccessFilter(value)
           setAccessSelections([value])
         }
@@ -98,6 +95,7 @@ export default function FilterPrice({
           setServiceSelections([otherValue])
         } else {
           await applyServiceFilter(undefined)
+          setServiceSelections([])
         }
       } else {
         if (serviceSelections.length) {
@@ -132,7 +130,6 @@ export default function FilterPrice({
       {serviceFilterItems.map((e, index) => {
         const isServiceSelected =
           e.value === serviceType || serviceSelections.includes(e.value)
-        console.log('IS SELECTED service: ', isServiceSelected)
         const selectFilter = cx({
           [styles.selected]: isServiceSelected,
           [styles.filter]: true
@@ -154,8 +151,6 @@ export default function FilterPrice({
       {accessFilterItems.map((e, index) => {
         const isAccessSelected =
           e.value === accessType || accessSelections.includes(e.value)
-        console.log('IS SELECTED access: ', isAccessSelected, accessSelections)
-
         const selectFilter = cx({
           [styles.selected]: isAccessSelected,
           [styles.filter]: true

--- a/src/components/templates/Search/filterService.tsx
+++ b/src/components/templates/Search/filterService.tsx
@@ -2,7 +2,11 @@ import React, { ReactElement, useState } from 'react'
 import { useNavigate } from '@reach/router'
 import styles from './filterService.module.css'
 import classNames from 'classnames/bind'
-import { addExistingParamsToUrl, FilterByTypeOptions } from './utils'
+import {
+  addExistingParamsToUrl,
+  FilterByAccessOptions,
+  FilterByTypeOptions
+} from './utils'
 import Button from '../../atoms/Button'
 
 const cx = classNames.bind(styles)
@@ -14,15 +18,25 @@ const serviceFilterItems = [
   { display: 'algorithms', value: FilterByTypeOptions.Algorithm }
 ]
 
+const accessFilterItems = [
+  { display: 'download ', value: FilterByAccessOptions.Download },
+  { display: 'compute ', value: FilterByAccessOptions.Compute }
+]
+
 export default function FilterPrice({
   serviceType,
-  setServiceType
+  accessType,
+  setServiceType,
+  setAccessType
 }: {
   serviceType: string
+  accessType: string
   setServiceType: React.Dispatch<React.SetStateAction<string>>
+  setAccessType: React.Dispatch<React.SetStateAction<string>>
 }): ReactElement {
   const navigate = useNavigate()
   const [serviceSelections, setServiceSelections] = useState<string[]>([])
+  const [accessSelections, setAccessSelections] = useState<string[]>([])
 
   async function applyServiceFilter(filterBy: string) {
     let urlLocation = await addExistingParamsToUrl(location, ['serviceType'])
@@ -33,38 +47,82 @@ export default function FilterPrice({
     navigate(urlLocation)
   }
 
+  async function applyAccessFilter(filterBy: string) {
+    let urlLocation = await addExistingParamsToUrl(location, ['accessType'])
+    if (filterBy && location.search.indexOf('&accessType') === -1) {
+      urlLocation = `${urlLocation}&accessType=${filterBy}`
+    }
+    setAccessType(filterBy)
+    navigate(urlLocation)
+  }
+
   async function handleSelectedFilter(isSelected: boolean, value: string) {
-    if (isSelected) {
-      if (serviceSelections.length > 1) {
-        const otherValue = serviceFilterItems.find(
-          (p) => p.value !== value
-        ).value
-        await applyServiceFilter(otherValue)
-        setServiceSelections([otherValue])
+    if (
+      value === FilterByAccessOptions.Download ||
+      value === FilterByAccessOptions.Compute
+    ) {
+      if (isSelected) {
+        if (accessSelections.length > 1) {
+          // both selected -> select the other one
+          const otherValue = accessFilterItems.find(
+            (p) => p.value !== value
+          ).value
+          console.log('VALUE both selected -> select the other one: ', value)
+          await applyAccessFilter(otherValue)
+        } else {
+          // only the current one selected -> deselect it
+          console.log('VALUE both selected -> select the other one: ', value)
+          await applyAccessFilter(undefined)
+        }
       } else {
-        await applyServiceFilter(undefined)
-        if (serviceSelections.includes(value)) {
-          serviceSelections.pop()
+        if (accessSelections.length > 0) {
+          // one already selected -> both selected
+          console.log('VALUE one already selected -> both selected: ', value)
+          await applyAccessFilter(FilterByAccessOptions.All)
+          setAccessSelections(accessFilterItems.map((p) => p.value))
+        } else {
+          // none selected -> select
+          console.log('VALUE none  selected -> select: ', value)
+          await applyAccessFilter(value)
+          setAccessSelections([value])
         }
       }
     } else {
-      if (serviceSelections.length) {
-        await applyServiceFilter(undefined)
-        setServiceSelections(serviceFilterItems.map((p) => p.value))
+      if (isSelected) {
+        if (serviceSelections.length > 1) {
+          const otherValue = serviceFilterItems.find(
+            (p) => p.value !== value
+          ).value
+          await applyServiceFilter(otherValue)
+          setServiceSelections([otherValue])
+        } else {
+          await applyServiceFilter(undefined)
+        }
       } else {
-        await applyServiceFilter(value)
-        setServiceSelections([value])
+        if (serviceSelections.length) {
+          await applyServiceFilter(undefined)
+          setServiceSelections(serviceFilterItems.map((p) => p.value))
+        } else {
+          await applyServiceFilter(value)
+          setServiceSelections([value])
+        }
       }
     }
   }
 
   async function applyClearFilter() {
-    let urlLocation = await addExistingParamsToUrl(location, ['serviceType'])
+    let urlLocation = await addExistingParamsToUrl(location, [
+      'accessType',
+      'serviceType'
+    ])
 
     urlLocation = `${urlLocation}`
 
     setServiceSelections([])
+    setAccessSelections([])
+
     setServiceType(undefined)
+    setAccessType(undefined)
     navigate(urlLocation)
   }
 
@@ -85,6 +143,33 @@ export default function FilterPrice({
             className={selectFilter}
             onClick={async () => {
               handleSelectedFilter(isServiceSelected, e.value)
+            }}
+          >
+            {e.display}
+          </Button>
+        )
+      })}
+      {accessFilterItems.map((e, index) => {
+        console.log(
+          'ACCESS SELECTIONS: ',
+          accessSelections,
+          e.value,
+          accessSelections.includes(e.value)
+        )
+        const isAccessSelected =
+          e.value === accessType || accessSelections.includes(e.value)
+        const selectFilter = cx({
+          [styles.selected]: isAccessSelected,
+          [styles.filter]: true
+        })
+        return (
+          <Button
+            size="small"
+            style="text"
+            key={index}
+            className={selectFilter}
+            onClick={async () => {
+              handleSelectedFilter(isAccessSelected, e.value)
             }}
           >
             {e.display}

--- a/src/components/templates/Search/filterService.tsx
+++ b/src/components/templates/Search/filterService.tsx
@@ -38,32 +38,11 @@ export default function FilterPrice({
   const [serviceSelections, setServiceSelections] = useState<string[]>([])
   const [accessSelections, setAccessSelections] = useState<string[]>([])
 
-  async function applyServiceFilter(filterBy: string) {
-    let urlLocation = await addExistingParamsToUrl(location, ['serviceType'])
-    if (filterBy && location.search.indexOf('&serviceType') === -1) {
-      urlLocation = `${urlLocation}&serviceType=${filterBy}`
-    }
-    setServiceType(filterBy)
-    navigate(urlLocation)
-  }
-
-  async function applyAccessFilter(filterBy: string) {
-    let urlLocation = await addExistingParamsToUrl(location, ['accessType'])
-    if (filterBy && location.search.indexOf('&accessType') === -1) {
-      urlLocation = `${urlLocation}&accessType=${filterBy}`
-    }
-    setAccessType(filterBy)
-    navigate(urlLocation)
-  }
-
   async function applyFilter(filter: string, filterType: string) {
-    console.log('APPLY FILTER: ', filter, filterType)
     let urlLocation = ''
     if (filterType.localeCompare('accessType') === 0) {
-      console.log('IS ACCESS TYPE')
       urlLocation = await addExistingParamsToUrl(location, ['accessType'])
     } else {
-      console.log('IS SERVICE TYPE')
       urlLocation = await addExistingParamsToUrl(location, ['serviceType'])
     }
 
@@ -78,7 +57,6 @@ export default function FilterPrice({
   }
 
   async function handleSelectedFilter(isSelected: boolean, value: string) {
-    console.log('IS SELECTED, VALUE: ', isSelected, value)
     if (
       value === FilterByAccessOptions.Download ||
       value === FilterByAccessOptions.Compute

--- a/src/components/templates/Search/filterService.tsx
+++ b/src/components/templates/Search/filterService.tsx
@@ -148,7 +148,7 @@ export default function FilterPrice({
           </Button>
         )
       })}
-      &nbsp;&nbsp;&nbsp;
+      <div className={styles.separator} />
       {accessFilterItems.map((e, index) => {
         const isAccessSelected =
           e.value === accessType || accessSelections.includes(e.value)

--- a/src/components/templates/Search/index.tsx
+++ b/src/components/templates/Search/index.tsx
@@ -21,11 +21,13 @@ export default function SearchPage({
 }): ReactElement {
   const { appConfig } = useSiteMetadata()
   const parsed = queryString.parse(location.search)
-  const { text, owner, tags, page, sort, sortOrder, serviceType } = parsed
+  const { text, owner, tags, page, sort, sortOrder, serviceType, accessType } =
+    parsed
   const { chainIds } = useUserPreferences()
   const [queryResult, setQueryResult] = useState<QueryResult>()
   const [loading, setLoading] = useState<boolean>()
   const [service, setServiceType] = useState<string>(serviceType as string)
+  const [access, setAccessType] = useState<string>(accessType as string)
   const [sortType, setSortType] = useState<string>(sort as string)
   const [sortDirection, setSortDirection] = useState<string>(
     sortOrder as string
@@ -53,6 +55,7 @@ export default function SearchPage({
     sort,
     page,
     serviceType,
+    accessType,
     sortOrder,
     appConfig.metadataCacheUri,
     chainIds
@@ -74,7 +77,9 @@ export default function SearchPage({
           <div className={styles.row}>
             <ServiceFilter
               serviceType={service}
+              accessType={access}
               setServiceType={setServiceType}
+              setAccessType={setAccessType}
             />
             <Sort
               sortType={sortType}

--- a/src/components/templates/Search/utils.ts
+++ b/src/components/templates/Search/utils.ts
@@ -35,8 +35,7 @@ type FilterByTypeOptions =
 
 export const FilterByAccessOptions = {
   Download: 'access',
-  Compute: 'compute',
-  All: 'all'
+  Compute: 'compute'
 }
 type FilterByAccessOptions =
   typeof FilterByAccessOptions[keyof typeof FilterByAccessOptions]
@@ -65,7 +64,6 @@ export function getSearchQuery(
   const sortTerm = getSortType(sort)
   const sortValue = sortOrder === SortValueOptions.Ascending ? 1 : -1
   const emptySearchTerm = text === undefined || text === ''
-  console.log('ACESS TYPE: ', accessType)
   let searchTerm = owner
     ? `(publicKey.owner:${owner})`
     : tags
@@ -216,7 +214,6 @@ export async function getResults(
     serviceType,
     accessType
   )
-  console.log('SEARCH QUERY: ', searchQuery)
   const source = axios.CancelToken.source()
   // const queryResult = await metadataCache.queryMetadata(searchQuery)
   const queryResult = await queryMetadata(searchQuery, source.token)


### PR DESCRIPTION
Fixes #814 .

Changes proposed in this PR:

- add service access type filters `download` and `compute` to the existing filters