### PR TITLE
add total user liquidity, new Profile provider

### DIFF
--- a/src/components/atoms/Tooltip.module.css
+++ b/src/components/atoms/Tooltip.module.css
@@ -9,6 +9,10 @@
   font-size: var(--font-size-small);
 }
 
+.content p {
+  margin: 0;
+}
+
 .icon {
   width: 1em;
   height: 1em;

--- a/src/components/atoms/Tooltip.tsx
+++ b/src/components/atoms/Tooltip.tsx
@@ -5,6 +5,7 @@ import { useSpring, animated } from 'react-spring'
 import styles from './Tooltip.module.css'
 import { ReactComponent as Info } from '../../images/info.svg'
 import { Placement } from 'tippy.js'
+import Markdown from './Markdown'
 
 const cx = classNames.bind(styles)
 

--- a/src/components/molecules/AssetListTitle.tsx
+++ b/src/components/molecules/AssetListTitle.tsx
@@ -1,5 +1,4 @@
 import { DDO } from '@oceanprotocol/lib'
-import { useOcean } from '../../providers/Ocean'
 import { Link } from 'gatsby'
 import React, { ReactElement, useEffect, useState } from 'react'
 import { getAssetsNames } from '../../utils/aquarius'

--- a/src/components/molecules/AssetListTitle.tsx
+++ b/src/components/molecules/AssetListTitle.tsx
@@ -42,7 +42,7 @@ export default function AssetListTitle({
 
   return (
     <h3 className={styles.title}>
-      <Link to={`/asset/${did || ddo.id}`}>{assetTitle}</Link>
+      <Link to={`/asset/${did || ddo?.id}`}>{assetTitle}</Link>
     </h3>
   )
 }

--- a/src/components/molecules/AssetTeaser.tsx
+++ b/src/components/molecules/AssetTeaser.tsx
@@ -13,11 +13,13 @@ import { BestPrice } from '../../models/BestPrice'
 declare type AssetTeaserProps = {
   ddo: DDO
   price: BestPrice
+  noPublisher?: boolean
 }
 
 const AssetTeaser: React.FC<AssetTeaserProps> = ({
   ddo,
-  price
+  price,
+  noPublisher
 }: AssetTeaserProps) => {
   const { attributes } = ddo.findServiceByType('metadata')
   const { name, type } = attributes.main
@@ -34,7 +36,9 @@ const AssetTeaser: React.FC<AssetTeaserProps> = ({
           <Dotdotdot clamp={3}>
             <h1 className={styles.title}>{name}</h1>
           </Dotdotdot>
-          <Publisher account={owner} minimal className={styles.publisher} />
+          {!noPublisher && (
+            <Publisher account={owner} minimal className={styles.publisher} />
+          )}
         </header>
 
         <AssetType

--- a/src/components/molecules/Bookmarks.tsx
+++ b/src/components/molecules/Bookmarks.tsx
@@ -5,10 +5,7 @@ import { Logger } from '@oceanprotocol/lib'
 import Price from '../atoms/Price'
 import Tooltip from '../atoms/Tooltip'
 import AssetTitle from './AssetListTitle'
-import {
-  queryMetadata,
-  transformChainIdsListToQuery
-} from '../../utils/aquarius'
+import { getAssetsFromDidList } from '../../utils/aquarius'
 import { getAssetsBestPrices, AssetListPrices } from '../../utils/subgraph'
 import axios, { CancelToken } from 'axios'
 import { useSiteMetadata } from '../../hooks/useSiteMetadata'
@@ -18,31 +15,8 @@ async function getAssetsBookmarked(
   chainIds: number[],
   cancelToken: CancelToken
 ) {
-  const searchDids = JSON.stringify(bookmarks)
-    .replace(/,/g, ' ')
-    .replace(/"/g, '')
-    .replace(/(\[|\])/g, '')
-    // for whatever reason ddo.id is not searchable, so use ddo.dataToken instead
-    .replace(/(did:op:)/g, '0x')
-
-  const queryBookmarks = {
-    page: 1,
-    offset: 100,
-    query: {
-      query_string: {
-        query: `(${searchDids}) AND (${transformChainIdsListToQuery(
-          chainIds
-        )})`,
-        fields: ['dataToken'],
-        default_operator: 'OR'
-      }
-    },
-    sort: { created: -1 }
-  }
-
   try {
-    const result = await queryMetadata(queryBookmarks, cancelToken)
-
+    const result = await getAssetsFromDidList(bookmarks, chainIds, cancelToken)
     return result
   } catch (error) {
     Logger.error(error.message)
@@ -88,7 +62,7 @@ export default function Bookmarks(): ReactElement {
   const { chainIds } = useUserPreferences()
 
   useEffect(() => {
-    if (!appConfig.metadataCacheUri || bookmarks === []) return
+    if (!appConfig?.metadataCacheUri || bookmarks === []) return
 
     const source = axios.CancelToken.source()
 
@@ -121,7 +95,7 @@ export default function Bookmarks(): ReactElement {
     return () => {
       source.cancel()
     }
-  }, [bookmarks, chainIds])
+  }, [bookmarks, chainIds, appConfig?.metadataCacheUri])
 
   return (
     <Table

--- a/src/components/molecules/NumberUnit.module.css
+++ b/src/components/molecules/NumberUnit.module.css
@@ -3,6 +3,7 @@
   font-weight: var(--font-weight-bold);
   font-size: var(--font-size-h4);
   color: var(--font-color-heading);
+  margin-left: 0;
 }
 
 .number {

--- a/src/components/molecules/NumberUnit.module.css
+++ b/src/components/molecules/NumberUnit.module.css
@@ -47,3 +47,9 @@
   background: var(--brand-white);
   border: 0.1rem solid var(--brand-pink);
 }
+
+.tooltip svg {
+  width: 0.8em !important;
+  height: 0.8em !important;
+  margin-left: 0;
+}

--- a/src/components/molecules/NumberUnit.tsx
+++ b/src/components/molecules/NumberUnit.tsx
@@ -1,45 +1,38 @@
 import React, { ReactElement } from 'react'
+import Markdown from '../atoms/Markdown'
+import Tooltip from '../atoms/Tooltip'
 import styles from './NumberUnit.module.css'
 
-interface NumberInnerProps {
+interface NumberUnitProps {
   label: string
   value: number | string | Element | ReactElement
   small?: boolean
   icon?: Element | ReactElement
+  tooltip?: string
 }
-
-interface NumberUnitProps extends NumberInnerProps {
-  link?: string
-  linkTooltip?: string
-}
-
-const NumberInner = ({ small, label, value, icon }: NumberInnerProps) => (
-  <>
-    <div className={`${styles.number} ${small && styles.small}`}>
-      {icon && icon}
-      {value}
-    </div>
-    <span className={styles.label}>{label}</span>
-  </>
-)
 
 export default function NumberUnit({
-  link,
-  linkTooltip,
   small,
   label,
   value,
-  icon
+  icon,
+  tooltip
 }: NumberUnitProps): ReactElement {
   return (
     <div className={styles.unit}>
-      {link ? (
-        <a href={link} title={linkTooltip}>
-          <NumberInner small={small} label={label} value={value} icon={icon} />
-        </a>
-      ) : (
-        <NumberInner small={small} label={label} value={value} icon={icon} />
-      )}
+      <div className={`${styles.number} ${small && styles.small}`}>
+        {icon && icon}
+        {value}
+      </div>
+      <span className={styles.label}>
+        {label}{' '}
+        {tooltip && (
+          <Tooltip
+            content={<Markdown text={tooltip} />}
+            className={styles.tooltip}
+          />
+        )}
+      </span>
     </div>
   )
 }

--- a/src/components/molecules/PoolTransactions/Title.tsx
+++ b/src/components/molecules/PoolTransactions/Title.tsx
@@ -68,6 +68,7 @@ export default function Title({ row }: { row: PoolTransaction }): ReactElement {
 
   useEffect(() => {
     if (!locale || !row) return
+
     async function init() {
       const title = await getTitle(row, locale)
       setTitle(title)

--- a/src/components/organisms/AssetList.tsx
+++ b/src/components/organisms/AssetList.tsx
@@ -26,6 +26,7 @@ declare type AssetListProps = {
   isLoading?: boolean
   onPageChange?: React.Dispatch<React.SetStateAction<number>>
   className?: string
+  noPublisher?: boolean
 }
 
 const AssetList: React.FC<AssetListProps> = ({
@@ -35,7 +36,8 @@ const AssetList: React.FC<AssetListProps> = ({
   totalPages,
   isLoading,
   onPageChange,
-  className
+  className,
+  noPublisher
 }) => {
   const { chainIds } = useUserPreferences()
   const [assetsWithPrices, setAssetWithPrices] = useState<AssetListPrices[]>()
@@ -71,6 +73,7 @@ const AssetList: React.FC<AssetListProps> = ({
               ddo={assetWithPrice.ddo}
               price={assetWithPrice.price}
               key={assetWithPrice.ddo.id}
+              noPublisher={noPublisher}
             />
           ))
         ) : chainIds.length === 0 ? (

--- a/src/components/pages/Profile/Header/Account.tsx
+++ b/src/components/pages/Profile/Header/Account.tsx
@@ -7,23 +7,26 @@ import jellyfish from '@oceanprotocol/art/creatures/jellyfish/jellyfish-grid.svg
 import Copy from '../../../atoms/Copy'
 import Blockies from '../../../atoms/Blockies'
 import styles from './Account.module.css'
+import { useProfile } from '../../../../providers/Profile'
 
 export default function Account({
-  name,
-  image,
   accountId
 }: {
-  name: string
-  image: string
   accountId: string
 }): ReactElement {
   const { chainIds } = useUserPreferences()
+  const { profile } = useProfile()
 
   return (
     <div className={styles.account}>
       <figure className={styles.imageWrap}>
-        {image ? (
-          <img src={image} className={styles.image} width="96" height="96" />
+        {profile?.image ? (
+          <img
+            src={profile?.image}
+            className={styles.image}
+            width="96"
+            height="96"
+          />
         ) : accountId ? (
           <Blockies accountId={accountId} className={styles.image} />
         ) : (
@@ -37,7 +40,9 @@ export default function Account({
       </figure>
 
       <div>
-        <h3 className={styles.name}>{name || accountTruncate(accountId)}</h3>
+        <h3 className={styles.name}>
+          {profile?.name || accountTruncate(accountId)}
+        </h3>
         {accountId && (
           <code className={styles.accountId}>
             {accountId} <Copy text={accountId} />

--- a/src/components/pages/Profile/Header/PublisherLinks.tsx
+++ b/src/components/pages/Profile/Header/PublisherLinks.tsx
@@ -1,18 +1,18 @@
 import React, { ReactElement } from 'react'
 import classNames from 'classnames/bind'
-import { ProfileLink } from '../../../../models/Profile'
 import { ReactComponent as External } from '../../../../images/external.svg'
 import styles from './PublisherLinks.module.css'
+import { useProfile } from '../../../../providers/Profile'
 
 const cx = classNames.bind(styles)
 
 export default function PublisherLinks({
-  links,
   className
 }: {
-  links: ProfileLink[]
   className: string
 }): ReactElement {
+  const { profile } = useProfile()
+
   const styleClasses = cx({
     links: true,
     [className]: className
@@ -21,7 +21,7 @@ export default function PublisherLinks({
   return (
     <div className={styleClasses}>
       {' — '}
-      {links?.map((link: ProfileLink) => {
+      {profile?.links?.map((link) => {
         const href =
           link.name === 'Twitter'
             ? `https://twitter.com/${link.value}`

--- a/src/components/pages/Profile/Header/Stats.module.css
+++ b/src/components/pages/Profile/Header/Stats.module.css
@@ -1,6 +1,6 @@
 .stats {
   display: grid;
   gap: var(--spacer);
-  grid-template-columns: repeat(auto-fit, minmax(8rem, 1fr));
-  margin-top: calc(var(--spacer) / 2);
+  grid-template-columns: repeat(auto-fit, minmax(9rem, 1fr));
+  margin-top: var(--spacer);
 }

--- a/src/components/pages/Profile/Header/Stats.tsx
+++ b/src/components/pages/Profile/Header/Stats.tsx
@@ -49,6 +49,8 @@ export default function Stats({
     }
 
     async function getSales() {
+      if (!assets) return
+
       try {
         const nrOrders = await getAccountNumberOfOrders(assets, chainIds)
         setSold(nrOrders)
@@ -60,7 +62,7 @@ export default function Stats({
   }, [accountId, chainIds, assets])
 
   useEffect(() => {
-    if (!assets) return
+    if (!assets || !accountId || !chainIds) return
 
     async function getPublisherLiquidity() {
       try {

--- a/src/components/pages/Profile/Header/Stats.tsx
+++ b/src/components/pages/Profile/Header/Stats.tsx
@@ -34,7 +34,7 @@ export default function Stats({
   accountId: string
 }): ReactElement {
   const { chainIds } = useUserPreferences()
-  const { poolShares, assets, assetsTotal } = useProfile()
+  const { poolShares, assets, assetsTotal, downloadsTotal } = useProfile()
 
   const [sold, setSold] = useState(0)
   const [publisherLiquidity, setPublisherLiquidity] = useState<UserLiquidity>()
@@ -112,8 +112,13 @@ export default function Stats({
         label="Total Liquidity"
         value={<Conversion price={`${totalLiquidity}`} hideApproximateSymbol />}
       />
-      <NumberUnit label="Sales" value={sold} />
+      <NumberUnit label={`Sale${sold === 1 ? '' : 's'}`} value={sold} />
       <NumberUnit label="Published" value={assetsTotal} />
+      <NumberUnit
+        label={`Download${downloadsTotal === 1 ? '' : 's'}`}
+        tooltip="Datatoken orders for assets with `access` service, as opposed to `compute`. As one order could allow multiple or infinite downloads this number does not reflect the actual download count of an asset file."
+        value={downloadsTotal}
+      />
     </div>
   )
 }

--- a/src/components/pages/Profile/Header/index.tsx
+++ b/src/components/pages/Profile/Header/index.tsx
@@ -1,24 +1,14 @@
-import React, { ReactElement, useEffect, useState } from 'react'
-import get3BoxProfile from '../../../../utils/profile'
-import { Profile } from '../../../../models/Profile'
-import { accountTruncate } from '../../../../utils/web3'
-import axios from 'axios'
+import React, { ReactElement, useState } from 'react'
 import PublisherLinks from './PublisherLinks'
 import Markdown from '../../../atoms/Markdown'
 import Stats from './Stats'
 import Account from './Account'
 import styles from './index.module.css'
+import { useProfile } from '../../../../providers/Profile'
 
 const isDescriptionTextClamped = () => {
   const el = document.getElementById('description')
   if (el) return el.scrollHeight > el.clientHeight
-}
-
-const clearedProfile: Profile = {
-  name: null,
-  image: null,
-  description: null,
-  links: null
 }
 
 const Link3Box = ({ accountId, text }: { accountId: string; text: string }) => {
@@ -38,62 +28,22 @@ export default function AccountHeader({
 }: {
   accountId: string
 }): ReactElement {
-  const [profile, setProfile] = useState<Profile>({
-    name: accountTruncate(accountId),
-    image: null,
-    description: null,
-    links: null
-  })
+  const { profile } = useProfile()
   const [isShowMore, setIsShowMore] = useState(false)
 
   const toogleShowMore = () => {
     setIsShowMore(!isShowMore)
   }
 
-  useEffect(() => {
-    if (!accountId) {
-      setProfile(clearedProfile)
-      return
-    }
-
-    const source = axios.CancelToken.source()
-
-    async function getInfoFrom3Box() {
-      const profile3Box = await get3BoxProfile(accountId, source.token)
-      if (profile3Box) {
-        const { name, emoji, description, image, links } = profile3Box
-        const newName = `${emoji || ''} ${name || accountTruncate(accountId)}`
-        const newProfile = {
-          name: newName,
-          image,
-          description,
-          links
-        }
-        setProfile(newProfile)
-      } else {
-        setProfile(clearedProfile)
-      }
-    }
-    getInfoFrom3Box()
-
-    return () => {
-      source.cancel()
-    }
-  }, [accountId])
-
   return (
     <div className={styles.grid}>
       <div>
-        <Account
-          accountId={accountId}
-          image={profile.image}
-          name={profile.name}
-        />
+        <Account accountId={accountId} />
         <Stats accountId={accountId} />
       </div>
 
       <div>
-        <Markdown text={profile.description} className={styles.description} />
+        <Markdown text={profile?.description} className={styles.description} />
         {isDescriptionTextClamped() ? (
           <span className={styles.more} onClick={toogleShowMore}>
             <Link3Box accountId={accountId} text="Read more on 3box" />
@@ -101,11 +51,8 @@ export default function AccountHeader({
         ) : (
           ''
         )}
-        {profile.links?.length > 0 && (
-          <PublisherLinks
-            links={profile.links}
-            className={styles.publisherLinks}
-          />
+        {profile?.links?.length > 0 && (
+          <PublisherLinks className={styles.publisherLinks} />
         )}
       </div>
       <div className={styles.meta}>

--- a/src/components/pages/Profile/History/Downloads.tsx
+++ b/src/components/pages/Profile/History/Downloads.tsx
@@ -6,7 +6,7 @@ import web3 from 'web3'
 import AssetTitle from '../../../molecules/AssetListTitle'
 import axios from 'axios'
 import { retrieveDDO } from '../../../../utils/aquarius'
-import { Logger } from '@oceanprotocol/lib'
+import { DDO, Logger } from '@oceanprotocol/lib'
 import { useSiteMetadata } from '../../../../hooks/useSiteMetadata'
 import { useUserPreferences } from '../../../../providers/UserPreferences'
 import { fetchDataForMultipleChains } from '../../../../utils/subgraph'
@@ -31,17 +31,17 @@ const getTokenOrders = gql`
 `
 
 interface DownloadedAssets {
-  did: string
   dtSymbol: string
   timestamp: number
   networkId: number
+  ddo: DDO
 }
 
 const columns = [
   {
     name: 'Data Set',
     selector: function getAssetRow(row: DownloadedAssets) {
-      return <AssetTitle did={row.did} />
+      return <AssetTitle ddo={row.ddo} />
     }
   },
   {
@@ -104,7 +104,7 @@ export default function ComputeDownloads({
           if (!ddo) continue
           if (ddo.service[1].type === 'access') {
             filteredOrders.push({
-              did: did,
+              ddo,
               networkId: ddo.chainId,
               dtSymbol: data[i].datatokenId.symbol,
               timestamp: data[i].timestamp

--- a/src/components/pages/Profile/History/Downloads.tsx
+++ b/src/components/pages/Profile/History/Downloads.tsx
@@ -76,10 +76,11 @@ export default function ComputeDownloads({
 
   useEffect(() => {
     const variables = { user: accountId?.toLowerCase() }
+    const cancelTokenSource = axios.CancelToken.source()
 
     async function filterAssets() {
       const filteredOrders: DownloadedAssets[] = []
-      const source = axios.CancelToken.source()
+
       try {
         setIsLoading(true)
         const response = await fetchDataForMultipleChains(
@@ -99,7 +100,7 @@ export default function ComputeDownloads({
           const did = web3.utils
             .toChecksumAddress(data[i].datatokenId.address)
             .replace('0x', 'did:op:')
-          const ddo = await retrieveDDO(did, source.token)
+          const ddo = await retrieveDDO(did, cancelTokenSource.token)
           if (!ddo) continue
           if (ddo.service[1].type === 'access') {
             filteredOrders.push({
@@ -122,6 +123,10 @@ export default function ComputeDownloads({
     }
 
     filterAssets()
+
+    return () => {
+      cancelTokenSource.cancel()
+    }
   }, [accountId, appConfig.metadataCacheUri, chainIds])
 
   return accountId ? (

--- a/src/components/pages/Profile/History/PoolShares.tsx
+++ b/src/components/pages/Profile/History/PoolShares.tsx
@@ -159,13 +159,13 @@ export default function PoolShares({
 }: {
   accountId: string
 }): ReactElement {
-  const { poolShares, poolSharesLoading } = useProfile()
+  const { poolShares, isPoolSharesLoading } = useProfile()
   const [assets, setAssets] = useState<Asset[]>()
   const [loading, setLoading] = useState<boolean>(false)
   const [dataFetchInterval, setDataFetchInterval] = useState<NodeJS.Timeout>()
 
   const fetchPoolSharesAssets = useCallback(async () => {
-    if (!poolShares || poolSharesLoading) return
+    if (!poolShares || isPoolSharesLoading) return
 
     try {
       const assets = await getPoolSharesAssets(poolShares)
@@ -173,7 +173,7 @@ export default function PoolShares({
     } catch (error) {
       console.error('Error fetching pool shares: ', error.message)
     }
-  }, [poolShares, poolSharesLoading])
+  }, [poolShares, isPoolSharesLoading])
 
   useEffect(() => {
     async function init() {

--- a/src/components/pages/Profile/History/PoolShares.tsx
+++ b/src/components/pages/Profile/History/PoolShares.tsx
@@ -140,13 +140,15 @@ async function getPoolSharesAssets(
       .replace('0x', 'did:op:')
     const ddo = await retrieveDDO(did, cancelToken)
     const userLiquidity = calculateUserLiquidity(data[i])
-    assetList.push({
-      poolShare: data[i],
-      userLiquidity: userLiquidity,
-      networkId: ddo?.chainId,
-      createTime: data[i].poolId.createTime,
-      ddo
-    })
+
+    ddo &&
+      assetList.push({
+        poolShare: data[i],
+        userLiquidity: userLiquidity,
+        networkId: ddo?.chainId,
+        createTime: data[i].poolId.createTime,
+        ddo
+      })
   }
   const assets = assetList.sort((a, b) => b.createTime - a.createTime)
   return assets

--- a/src/components/pages/Profile/History/PoolShares.tsx
+++ b/src/components/pages/Profile/History/PoolShares.tsx
@@ -9,17 +9,14 @@ import {
 } from '../../../../@types/apollo/PoolShares'
 import web3 from 'web3'
 import Token from '../../../organisms/AssetActions/Pool/Token'
-import { useUserPreferences } from '../../../../providers/UserPreferences'
-import {
-  calculateUserLiquidity,
-  getPoolSharesData
-} from '../../../../utils/subgraph'
+import { calculateUserLiquidity } from '../../../../utils/subgraph'
 import NetworkName from '../../../atoms/NetworkName'
 import axios, { CancelToken } from 'axios'
 import { retrieveDDO } from '../../../../utils/aquarius'
 import { isValidNumber } from '../../../../utils/numberValidations'
 import Decimal from 'decimal.js'
 import { useProfile } from '../../../../providers/Profile'
+import { DDO } from '@oceanprotocol/lib'
 
 Decimal.set({ toExpNeg: -18, precision: 18, rounding: 1 })
 
@@ -30,6 +27,7 @@ interface Asset {
   poolShare: PoolShare
   networkId: number
   createTime: number
+  ddo: DDO
 }
 
 function findTokenByType(tokens: PoolSharePoolIdTokens[], type: string) {
@@ -98,10 +96,7 @@ const columns = [
   {
     name: 'Data Set',
     selector: function getAssetRow(row: Asset) {
-      const did = web3.utils
-        .toChecksumAddress(row.poolShare.poolId.datatokenAddress)
-        .replace('0x', 'did:op:')
-      return <AssetTitle did={did} />
+      return <AssetTitle ddo={row.ddo} />
     },
     grow: 2
   },
@@ -149,7 +144,8 @@ async function getPoolSharesAssets(
       poolShare: data[i],
       userLiquidity: userLiquidity,
       networkId: ddo?.chainId,
-      createTime: data[i].poolId.createTime
+      createTime: data[i].poolId.createTime,
+      ddo
     })
   }
   const assets = assetList.sort((a, b) => b.createTime - a.createTime)

--- a/src/components/pages/Profile/History/PublishedList.tsx
+++ b/src/components/pages/Profile/History/PublishedList.tsx
@@ -69,6 +69,7 @@ export default function PublishedList({
           setPage(newPage)
         }}
         className={styles.assets}
+        noPublisher
       />
     </>
   ) : (

--- a/src/components/pages/Profile/History/PublishedList.tsx
+++ b/src/components/pages/Profile/History/PublishedList.tsx
@@ -2,11 +2,7 @@ import { Logger } from '@oceanprotocol/lib'
 import { QueryResult } from '@oceanprotocol/lib/dist/node/metadatacache/MetadataCache'
 import React, { ReactElement, useEffect, useState } from 'react'
 import AssetList from '../../../organisms/AssetList'
-import axios from 'axios'
-import {
-  queryMetadata,
-  transformChainIdsListToQuery
-} from '../../../../utils/aquarius'
+import { getPublishedAssets } from '../../../../utils/aquarius'
 import Filters from '../../../templates/Search/Filters'
 import { useSiteMetadata } from '../../../../hooks/useSiteMetadata'
 import { useUserPreferences } from '../../../../providers/UserPreferences'
@@ -23,30 +19,20 @@ export default function PublishedList({
   const [queryResult, setQueryResult] = useState<QueryResult>()
   const [isLoading, setIsLoading] = useState(false)
   const [page, setPage] = useState<number>(1)
-  const [service, setServiceType] = useState<string>()
+  const [service, setServiceType] = useState('dataset OR algorithm')
 
   useEffect(() => {
     async function getPublished() {
-      const serviceFiter =
-        service === undefined ? 'dataset OR algorithm' : `${service}`
       if (!accountId) return
-      const queryPublishedAssets = {
-        page: page,
-        offset: 9,
-        query: {
-          query_string: {
-            query: `(publicKey.owner:${accountId}) AND (service.attributes.main.type:${serviceFiter}) AND (${transformChainIdsListToQuery(
-              chainIds
-            )})`
-          }
-        },
-        sort: { created: -1 }
-      }
-      try {
-        const source = axios.CancelToken.source()
 
+      try {
         setIsLoading(true)
-        const result = await queryMetadata(queryPublishedAssets, source.token)
+        const result = await getPublishedAssets(
+          accountId,
+          chainIds,
+          page,
+          service
+        )
         setQueryResult(result)
       } catch (error) {
         Logger.error(error.message)

--- a/src/components/pages/Profile/History/PublishedList.tsx
+++ b/src/components/pages/Profile/History/PublishedList.tsx
@@ -7,6 +7,7 @@ import Filters from '../../../templates/Search/Filters'
 import { useSiteMetadata } from '../../../../hooks/useSiteMetadata'
 import { useUserPreferences } from '../../../../providers/UserPreferences'
 import styles from './PublishedList.module.css'
+import axios from 'axios'
 
 export default function PublishedList({
   accountId
@@ -22,14 +23,17 @@ export default function PublishedList({
   const [service, setServiceType] = useState('dataset OR algorithm')
 
   useEffect(() => {
-    async function getPublished() {
-      if (!accountId) return
+    if (!accountId) return
 
+    const cancelTokenSource = axios.CancelToken.source()
+
+    async function getPublished() {
       try {
         setIsLoading(true)
         const result = await getPublishedAssets(
           accountId,
           chainIds,
+          cancelTokenSource.token,
           page,
           service
         )
@@ -41,6 +45,10 @@ export default function PublishedList({
       }
     }
     getPublished()
+
+    return () => {
+      cancelTokenSource.cancel()
+    }
   }, [accountId, page, appConfig.metadataCacheUri, chainIds, service])
 
   return accountId ? (

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -4,6 +4,7 @@ import { graphql, PageProps } from 'gatsby'
 import ProfilePage from '../../components/pages/Profile'
 import { accountTruncate } from '../../utils/web3'
 import { useWeb3 } from '../../providers/Web3'
+import ProfileProvider from '../../providers/Profile'
 
 export default function PageGatsbyProfile(props: PageProps): ReactElement {
   const { accountId } = useWeb3()
@@ -18,7 +19,9 @@ export default function PageGatsbyProfile(props: PageProps): ReactElement {
 
   return (
     <Page uri={props.uri} title={accountTruncate(finalAccountId)} noPageHeader>
-      <ProfilePage accountId={finalAccountId} />
+      <ProfileProvider accountId={finalAccountId}>
+        <ProfilePage accountId={finalAccountId} />
+      </ProfileProvider>
     </Page>
   )
 }

--- a/src/providers/Profile.tsx
+++ b/src/providers/Profile.tsx
@@ -1,0 +1,119 @@
+import React, {
+  useContext,
+  useState,
+  useEffect,
+  createContext,
+  ReactElement,
+  useCallback,
+  ReactNode
+} from 'react'
+import {
+  AssetListPrices,
+  getAssetsBestPrices,
+  getPoolSharesData
+} from '../utils/subgraph'
+import { useUserPreferences } from './UserPreferences'
+import { PoolShares_poolShares as PoolShare } from '../@types/apollo/PoolShares'
+import { DDO, Logger } from '@oceanprotocol/lib'
+import { getPublishedAssets } from '../utils/aquarius'
+import { useSiteMetadata } from '../hooks/useSiteMetadata'
+
+interface ProfileProviderValue {
+  poolShares: PoolShare[]
+  isPoolSharesLoading: boolean
+  assets: DDO[]
+  assetsTotal: number
+}
+
+const ProfileContext = createContext({} as ProfileProviderValue)
+
+const refreshInterval = 10000 // 10 sec.
+
+function ProfileProvider({
+  accountId,
+  children
+}: {
+  accountId: string
+  children: ReactNode
+}): ReactElement {
+  const { chainIds } = useUserPreferences()
+  const { appConfig } = useSiteMetadata()
+
+  //
+  // POOL SHARES
+  //
+  const [poolShares, setPoolShares] = useState<PoolShare[]>()
+  const [isPoolSharesLoading, setIsPoolSharesLoading] = useState<boolean>(false)
+  const [poolSharesInterval, setPoolSharesInterval] = useState<NodeJS.Timeout>()
+
+  const fetchPoolShares = useCallback(async () => {
+    if (!accountId || !chainIds) return
+
+    try {
+      setIsPoolSharesLoading(true)
+      const data = await getPoolSharesData(accountId, chainIds)
+      setPoolShares(data)
+    } catch (error) {
+      console.error('Error fetching pool shares: ', error.message)
+    } finally {
+      setIsPoolSharesLoading(false)
+    }
+  }, [accountId, chainIds])
+
+  useEffect(() => {
+    async function init() {
+      await fetchPoolShares()
+
+      if (poolSharesInterval) return
+      const interval = setInterval(async () => {
+        await fetchPoolShares()
+      }, refreshInterval)
+      setPoolSharesInterval(interval)
+    }
+    init()
+
+    return () => {
+      clearInterval(poolSharesInterval)
+    }
+  }, [poolSharesInterval, fetchPoolShares])
+
+  //
+  // PUBLISHED ASSETS
+  //
+  const [assets, setAssets] = useState<DDO[]>()
+  const [assetsTotal, setAssetsTotal] = useState(0)
+
+  useEffect(() => {
+    async function getAllPublished() {
+      if (!accountId) return
+
+      try {
+        const result = await getPublishedAssets(accountId, chainIds)
+        setAssets(result.results)
+        setAssetsTotal(result.totalResults)
+      } catch (error) {
+        Logger.error(error.message)
+      }
+    }
+    getAllPublished()
+  }, [accountId, appConfig.metadataCacheUri, chainIds])
+
+  return (
+    <ProfileContext.Provider
+      value={{
+        poolShares,
+        isPoolSharesLoading,
+        assets,
+        assetsTotal
+      }}
+    >
+      {children}
+    </ProfileContext.Provider>
+  )
+}
+
+// Helper hook to access the provider values
+const useProfile = (): ProfileProviderValue => useContext(ProfileContext)
+
+export { ProfileProvider, useProfile, ProfileProviderValue, ProfileContext }
+export default ProfileProvider

--- a/src/providers/Profile.tsx
+++ b/src/providers/Profile.tsx
@@ -23,6 +23,7 @@ interface ProfileProviderValue {
   isPoolSharesLoading: boolean
   assets: DDO[]
   assetsTotal: number
+  // assetsWithPrices: AssetListPrices[]
 }
 
 const ProfileContext = createContext({} as ProfileProviderValue)
@@ -82,6 +83,7 @@ function ProfileProvider({
   //
   const [assets, setAssets] = useState<DDO[]>()
   const [assetsTotal, setAssetsTotal] = useState(0)
+  // const [assetsWithPrices, setAssetsWithPrices] = useState<AssetListPrices[]>()
 
   useEffect(() => {
     async function getAllPublished() {
@@ -91,6 +93,12 @@ function ProfileProvider({
         const result = await getPublishedAssets(accountId, chainIds)
         setAssets(result.results)
         setAssetsTotal(result.totalResults)
+
+        // Hint: this would only make sense if we "search" in all subcomponents
+        // against this provider's state, meaning filtering via js rather then sending
+        // more queries to Aquarius.
+        // const assetsWithPrices = await getAssetsBestPrices(result.results)
+        // setAssetsWithPrices(assetsWithPrices)
       } catch (error) {
         Logger.error(error.message)
       }

--- a/src/providers/Profile.tsx
+++ b/src/providers/Profile.tsx
@@ -76,10 +76,13 @@ function ProfileProvider({
       return
     }
 
-    const source = axios.CancelToken.source()
+    const cancelTokenSource = axios.CancelToken.source()
 
     async function getInfoFrom3Box() {
-      const profile3Box = await get3BoxProfile(accountId, source.token)
+      const profile3Box = await get3BoxProfile(
+        accountId,
+        cancelTokenSource.token
+      )
       if (profile3Box) {
         const { name, emoji, description, image, links } = profile3Box
         const newName = `${emoji || ''} ${name || accountTruncate(accountId)}`
@@ -97,7 +100,7 @@ function ProfileProvider({
     getInfoFrom3Box()
 
     return () => {
-      source.cancel()
+      cancelTokenSource.cancel()
     }
   }, [accountId, isEthAddress])
 
@@ -147,11 +150,17 @@ function ProfileProvider({
   // const [assetsWithPrices, setAssetsWithPrices] = useState<AssetListPrices[]>()
 
   useEffect(() => {
-    async function getAllPublished() {
-      if (!accountId || !isEthAddress) return
+    if (!accountId || !isEthAddress) return
 
+    const cancelTokenSource = axios.CancelToken.source()
+
+    async function getAllPublished() {
       try {
-        const result = await getPublishedAssets(accountId, chainIds)
+        const result = await getPublishedAssets(
+          accountId,
+          chainIds,
+          cancelTokenSource.token
+        )
         setAssets(result.results)
         setAssetsTotal(result.totalResults)
 
@@ -165,6 +174,10 @@ function ProfileProvider({
       }
     }
     getAllPublished()
+
+    return () => {
+      cancelTokenSource.cancel()
+    }
   }, [accountId, appConfig.metadataCacheUri, chainIds, isEthAddress])
 
   return (

--- a/src/utils/aquarius.ts
+++ b/src/utils/aquarius.ts
@@ -208,6 +208,7 @@ export async function getAlgorithmDatasetsForCompute(
 export async function getPublishedAssets(
   accountId: string,
   chainIds: number[],
+  cancelToken: CancelToken,
   page?: number,
   type?: string
 ): Promise<QueryResult> {
@@ -230,10 +231,13 @@ export async function getPublishedAssets(
   }
 
   try {
-    const source = axios.CancelToken.source()
-    const result = await queryMetadata(queryPublishedAssets, source.token)
+    const result = await queryMetadata(queryPublishedAssets, cancelToken)
     return result
   } catch (error) {
-    Logger.error(error.message)
+    if (axios.isCancel(error)) {
+      Logger.log(error.message)
+    } else {
+      Logger.error(error.message)
+    }
   }
 }

--- a/src/utils/aquarius.ts
+++ b/src/utils/aquarius.ts
@@ -204,3 +204,36 @@ export async function getAlgorithmDatasetsForCompute(
   )
   return datasets
 }
+
+export async function getPublishedAssets(
+  accountId: string,
+  chainIds: number[],
+  page?: number,
+  type?: string
+): Promise<QueryResult> {
+  if (!accountId) return
+
+  page = page || 1
+  type = type || 'dataset OR algorithm'
+
+  const queryPublishedAssets = {
+    page,
+    offset: 9,
+    query: {
+      query_string: {
+        query: `(publicKey.owner:${accountId}) AND (service.attributes.main.type:${type}) AND (${transformChainIdsListToQuery(
+          chainIds
+        )})`
+      }
+    },
+    sort: { created: -1 }
+  }
+
+  try {
+    const source = axios.CancelToken.source()
+    const result = await queryMetadata(queryPublishedAssets, source.token)
+    return result
+  } catch (error) {
+    Logger.error(error.message)
+  }
+}

--- a/src/utils/aquarius.ts
+++ b/src/utils/aquarius.ts
@@ -66,7 +66,8 @@ export async function queryMetadata(
   try {
     const response: AxiosResponse<any> = await axios.post(
       `${metadataCacheUri}/api/v1/aquarius/assets/ddo/query`,
-      { ...query, cancelToken }
+      { ...query },
+      { cancelToken }
     )
     if (!response || response.status !== 200 || !response.data) return
     return transformQueryResult(response.data)
@@ -108,10 +109,8 @@ export async function getAssetsNames(
   try {
     const response: AxiosResponse<Record<string, string>> = await axios.post(
       `${metadataCacheUri}/api/v1/aquarius/assets/names`,
-      {
-        didList,
-        cancelToken
-      }
+      { didList },
+      { cancelToken }
     )
     if (!response || response.status !== 200 || !response.data) return
     return response.data

--- a/src/utils/aquarius.ts
+++ b/src/utils/aquarius.ts
@@ -12,7 +12,16 @@ import {
 import { AssetSelectionAsset } from '../components/molecules/FormFields/AssetSelection'
 import { PriceList, getAssetsPriceList } from './subgraph'
 import axios, { CancelToken, AxiosResponse } from 'axios'
+import { OrdersData_tokenOrders as OrdersData } from '../@types/apollo/OrdersData'
 import { metadataCacheUri } from '../../app.config'
+import web3 from '../../tests/unit/__mocks__/web3'
+
+export interface DownloadedAsset {
+  dtSymbol: string
+  timestamp: number
+  networkId: number
+  ddo: DDO
+}
 
 function getQueryForAlgorithmDatasets(algorithmDid: string, chainId?: number) {
   return {
@@ -238,5 +247,87 @@ export async function getPublishedAssets(
     } else {
       Logger.error(error.message)
     }
+  }
+}
+
+export async function getAssetsFromDidList(
+  didList: string[],
+  chainIds: number[],
+  cancelToken: CancelToken
+): Promise<QueryResult> {
+  try {
+    // TODO: figure out cleaner way to transform string[] into csv
+    const searchDids = JSON.stringify(didList)
+      .replace(/,/g, ' ')
+      .replace(/"/g, '')
+      .replace(/(\[|\])/g, '')
+      // for whatever reason ddo.id is not searchable, so use ddo.dataToken instead
+      .replace(/(did:op:)/g, '0x')
+
+    // safeguard against passed empty didList, preventing 500 from Aquarius
+    if (!searchDids) return
+
+    const query = {
+      page: 1,
+      offset: 1000,
+      query: {
+        query_string: {
+          query: `(${searchDids}) AND (${transformChainIdsListToQuery(
+            chainIds
+          )})`,
+          fields: ['dataToken'],
+          default_operator: 'OR'
+        }
+      },
+      sort: { created: -1 }
+    }
+
+    const queryResult = await queryMetadata(query, cancelToken)
+    return queryResult
+  } catch (error) {
+    Logger.error(error.message)
+  }
+}
+
+export async function getDownloadAssets(
+  didList: string[],
+  tokenOrders: OrdersData[],
+  chainIds: number[],
+  cancelToken: CancelToken
+): Promise<DownloadedAsset[]> {
+  const downloadedAssets: DownloadedAsset[] = []
+
+  try {
+    const queryResult = await getAssetsFromDidList(
+      didList,
+      chainIds,
+      cancelToken
+    )
+    const ddoList = queryResult?.results
+
+    for (let i = 0; i < tokenOrders?.length; i++) {
+      const ddo = ddoList.filter(
+        (ddo) =>
+          tokenOrders[i].datatokenId.address.toLowerCase() ===
+          ddo.dataToken.toLowerCase()
+      )[0]
+
+      // make sure we are only pushing download orders
+      if (ddo.service[1].type !== 'access') continue
+
+      downloadedAssets.push({
+        ddo,
+        networkId: ddo.chainId,
+        dtSymbol: tokenOrders[i].datatokenId.symbol,
+        timestamp: tokenOrders[i].timestamp
+      })
+    }
+
+    const sortedOrders = downloadedAssets.sort(
+      (a, b) => b.timestamp - a.timestamp
+    )
+    return sortedOrders
+  } catch (error) {
+    Logger.error(error.message)
   }
 }

--- a/src/utils/subgraph.ts
+++ b/src/utils/subgraph.ts
@@ -678,18 +678,3 @@ export async function getPoolSharesData(
   }
   return data
 }
-
-export async function getAccountLiquidity(
-  accountId: string,
-  chainIds: number[]
-): Promise<number> {
-  const poolShares = await getPoolSharesData(accountId, chainIds)
-
-  let totalLiquidity = 0
-  for (const poolShare of poolShares) {
-    const poolLiquidity = calculateUserLiquidity(poolShare)
-    totalLiquidity += poolLiquidity
-  }
-
-  return totalLiquidity
-}


### PR DESCRIPTION
- closes #839
- [new `ProfileProvider`](https://github.com/oceanprotocol/market/pull/841#issuecomment-915067025) wrapping profile pages, reducing lots of requests
- new stat: _Total Liquidity_
- renamed stat: _Liquidity in Own Assets_
- #849

Example:

<img width="1140" alt="Screen Shot 2021-09-07 at 13 22 21" src="https://user-images.githubusercontent.com/90316/132336685-ec4e9a50-ce2e-4669-b994-35ab83f5e79b.png">

https://market-git-feature-accountpageliquidity-oceanprotocol.vercel.app/profile/0xbbd33AFa85539fa65cc08A2e61a001876D2f13FE
