### PR TITLE
Add total downloads, speed up downloads fetching

### DIFF
--- a/src/components/atoms/Tooltip.module.css
+++ b/src/components/atoms/Tooltip.module.css
@@ -9,6 +9,10 @@
   font-size: var(--font-size-small);
 }
 
+.content p {
+  margin: 0;
+}
+
 .icon {
   width: 1em;
   height: 1em;

--- a/src/components/atoms/Tooltip.tsx
+++ b/src/components/atoms/Tooltip.tsx
@@ -5,6 +5,7 @@ import { useSpring, animated } from 'react-spring'
 import styles from './Tooltip.module.css'
 import { ReactComponent as Info } from '../../images/info.svg'
 import { Placement } from 'tippy.js'
+import Markdown from './Markdown'
 
 const cx = classNames.bind(styles)
 

--- a/src/components/molecules/Bookmarks.tsx
+++ b/src/components/molecules/Bookmarks.tsx
@@ -5,10 +5,7 @@ import { Logger } from '@oceanprotocol/lib'
 import Price from '../atoms/Price'
 import Tooltip from '../atoms/Tooltip'
 import AssetTitle from './AssetListTitle'
-import {
-  queryMetadata,
-  transformChainIdsListToQuery
-} from '../../utils/aquarius'
+import { getAssetsFromDidList } from '../../utils/aquarius'
 import { getAssetsBestPrices, AssetListPrices } from '../../utils/subgraph'
 import axios, { CancelToken } from 'axios'
 import { useSiteMetadata } from '../../hooks/useSiteMetadata'
@@ -18,31 +15,8 @@ async function getAssetsBookmarked(
   chainIds: number[],
   cancelToken: CancelToken
 ) {
-  const searchDids = JSON.stringify(bookmarks)
-    .replace(/,/g, ' ')
-    .replace(/"/g, '')
-    .replace(/(\[|\])/g, '')
-    // for whatever reason ddo.id is not searchable, so use ddo.dataToken instead
-    .replace(/(did:op:)/g, '0x')
-
-  const queryBookmarks = {
-    page: 1,
-    offset: 100,
-    query: {
-      query_string: {
-        query: `(${searchDids}) AND (${transformChainIdsListToQuery(
-          chainIds
-        )})`,
-        fields: ['dataToken'],
-        default_operator: 'OR'
-      }
-    },
-    sort: { created: -1 }
-  }
-
   try {
-    const result = await queryMetadata(queryBookmarks, cancelToken)
-
+    const result = await getAssetsFromDidList(bookmarks, chainIds, cancelToken)
     return result
   } catch (error) {
     Logger.error(error.message)
@@ -88,7 +62,7 @@ export default function Bookmarks(): ReactElement {
   const { chainIds } = useUserPreferences()
 
   useEffect(() => {
-    if (!appConfig.metadataCacheUri || bookmarks === []) return
+    if (!appConfig?.metadataCacheUri || bookmarks === []) return
 
     const source = axios.CancelToken.source()
 
@@ -121,7 +95,7 @@ export default function Bookmarks(): ReactElement {
     return () => {
       source.cancel()
     }
-  }, [bookmarks, chainIds])
+  }, [bookmarks, chainIds, appConfig?.metadataCacheUri])
 
   return (
     <Table

--- a/src/components/molecules/NumberUnit.module.css
+++ b/src/components/molecules/NumberUnit.module.css
@@ -47,3 +47,9 @@
   background: var(--brand-white);
   border: 0.1rem solid var(--brand-pink);
 }
+
+.tooltip svg {
+  width: 0.8em !important;
+  height: 0.8em !important;
+  margin-left: 0;
+}

--- a/src/components/molecules/NumberUnit.tsx
+++ b/src/components/molecules/NumberUnit.tsx
@@ -1,45 +1,38 @@
 import React, { ReactElement } from 'react'
+import Markdown from '../atoms/Markdown'
+import Tooltip from '../atoms/Tooltip'
 import styles from './NumberUnit.module.css'
 
-interface NumberInnerProps {
+interface NumberUnitProps {
   label: string
   value: number | string | Element | ReactElement
   small?: boolean
   icon?: Element | ReactElement
+  tooltip?: string
 }
-
-interface NumberUnitProps extends NumberInnerProps {
-  link?: string
-  linkTooltip?: string
-}
-
-const NumberInner = ({ small, label, value, icon }: NumberInnerProps) => (
-  <>
-    <div className={`${styles.number} ${small && styles.small}`}>
-      {icon && icon}
-      {value}
-    </div>
-    <span className={styles.label}>{label}</span>
-  </>
-)
 
 export default function NumberUnit({
-  link,
-  linkTooltip,
   small,
   label,
   value,
-  icon
+  icon,
+  tooltip
 }: NumberUnitProps): ReactElement {
   return (
     <div className={styles.unit}>
-      {link ? (
-        <a href={link} title={linkTooltip}>
-          <NumberInner small={small} label={label} value={value} icon={icon} />
-        </a>
-      ) : (
-        <NumberInner small={small} label={label} value={value} icon={icon} />
-      )}
+      <div className={`${styles.number} ${small && styles.small}`}>
+        {icon && icon}
+        {value}
+      </div>
+      <span className={styles.label}>
+        {label}{' '}
+        {tooltip && (
+          <Tooltip
+            content={<Markdown text={tooltip} />}
+            className={styles.tooltip}
+          />
+        )}
+      </span>
     </div>
   )
 }

--- a/src/components/pages/Profile/Header/Stats.tsx
+++ b/src/components/pages/Profile/Header/Stats.tsx
@@ -34,7 +34,7 @@ export default function Stats({
   accountId: string
 }): ReactElement {
   const { chainIds } = useUserPreferences()
-  const { poolShares, assets, assetsTotal } = useProfile()
+  const { poolShares, assets, assetsTotal, downloadsTotal } = useProfile()
 
   const [sold, setSold] = useState(0)
   const [publisherLiquidity, setPublisherLiquidity] = useState<UserLiquidity>()
@@ -114,6 +114,7 @@ export default function Stats({
       />
       <NumberUnit label="Sales" value={sold} />
       <NumberUnit label="Published" value={assetsTotal} />
+      <NumberUnit label="Downloads" value={downloadsTotal} />
     </div>
   )
 }

--- a/src/components/pages/Profile/Header/Stats.tsx
+++ b/src/components/pages/Profile/Header/Stats.tsx
@@ -114,7 +114,11 @@ export default function Stats({
       />
       <NumberUnit label="Sales" value={sold} />
       <NumberUnit label="Published" value={assetsTotal} />
-      <NumberUnit label="Downloads" value={downloadsTotal} />
+      <NumberUnit
+        label="Downloads"
+        tooltip="Datatoken orders for assets with `access` service, as opposed to `compute`. As one order could allow multiple or infinite downloads this number does not reflect the actual download count of an asset file."
+        value={downloadsTotal}
+      />
     </div>
   )
 }

--- a/src/components/pages/Profile/Header/Stats.tsx
+++ b/src/components/pages/Profile/Header/Stats.tsx
@@ -112,10 +112,10 @@ export default function Stats({
         label="Total Liquidity"
         value={<Conversion price={`${totalLiquidity}`} hideApproximateSymbol />}
       />
-      <NumberUnit label="Sales" value={sold} />
+      <NumberUnit label={`Sale${sold === 1 ? '' : 's'}`} value={sold} />
       <NumberUnit label="Published" value={assetsTotal} />
       <NumberUnit
-        label="Downloads"
+        label={`Download${downloadsTotal === 1 ? '' : 's'}`}
         tooltip="Datatoken orders for assets with `access` service, as opposed to `compute`. As one order could allow multiple or infinite downloads this number does not reflect the actual download count of an asset file."
         value={downloadsTotal}
       />

--- a/src/components/pages/Profile/History/Downloads.tsx
+++ b/src/components/pages/Profile/History/Downloads.tsx
@@ -1,64 +1,33 @@
-import React, { ReactElement, useEffect, useState } from 'react'
+import React, { ReactElement } from 'react'
 import Table from '../../../atoms/Table'
-import { gql } from 'urql'
 import Time from '../../../atoms/Time'
-import web3 from 'web3'
 import AssetTitle from '../../../molecules/AssetListTitle'
-import axios from 'axios'
-import { retrieveDDO } from '../../../../utils/aquarius'
-import { DDO, Logger } from '@oceanprotocol/lib'
-import { useSiteMetadata } from '../../../../hooks/useSiteMetadata'
-import { useUserPreferences } from '../../../../providers/UserPreferences'
-import { fetchDataForMultipleChains } from '../../../../utils/subgraph'
-import { OrdersData_tokenOrders as OrdersData } from '../../../../@types/apollo/OrdersData'
+import { DownloadedAsset } from '../../../../utils/subgraph'
 import NetworkName from '../../../atoms/NetworkName'
-
-const getTokenOrders = gql`
-  query OrdersData($user: String!) {
-    tokenOrders(
-      orderBy: timestamp
-      orderDirection: desc
-      where: { consumer: $user }
-    ) {
-      datatokenId {
-        address
-        symbol
-      }
-      timestamp
-      tx
-    }
-  }
-`
-
-interface DownloadedAssets {
-  dtSymbol: string
-  timestamp: number
-  networkId: number
-  ddo: DDO
-}
+import { useProfile } from '../../../../providers/Profile'
 
 const columns = [
   {
     name: 'Data Set',
-    selector: function getAssetRow(row: DownloadedAssets) {
+    selector: function getAssetRow(row: DownloadedAsset) {
       return <AssetTitle ddo={row.ddo} />
     }
   },
   {
     name: 'Network',
-    selector: function getNetwork(row: DownloadedAssets) {
+    selector: function getNetwork(row: DownloadedAsset) {
       return <NetworkName networkId={row.networkId} />
     }
   },
   {
     name: 'Datatoken',
-    selector: function getTitleRow(row: DownloadedAssets) {
+    selector: function getTitleRow(row: DownloadedAsset) {
       return row.dtSymbol
     }
   },
   {
     name: 'Time',
-    selector: function getTimeRow(row: DownloadedAssets) {
+    selector: function getTimeRow(row: DownloadedAsset) {
       return <Time date={row.timestamp.toString()} relative isUnix />
     }
   }
@@ -69,72 +38,14 @@ export default function ComputeDownloads({
 }: {
   accountId: string
 }): ReactElement {
-  const { appConfig } = useSiteMetadata()
-  const [isLoading, setIsLoading] = useState(false)
-  const [orders, setOrders] = useState<DownloadedAssets[]>()
-  const { chainIds } = useUserPreferences()
-
-  useEffect(() => {
-    const variables = { user: accountId?.toLowerCase() }
-    const cancelTokenSource = axios.CancelToken.source()
-
-    async function filterAssets() {
-      const filteredOrders: DownloadedAssets[] = []
-
-      try {
-        setIsLoading(true)
-        const response = await fetchDataForMultipleChains(
-          getTokenOrders,
-          variables,
-          chainIds
-        )
-
-        const data: OrdersData[] = []
-        for (let i = 0; i < response.length; i++) {
-          response[i].tokenOrders.forEach((tokenOrder: OrdersData) => {
-            data.push(tokenOrder)
-          })
-        }
-
-        for (let i = 0; i < data.length; i++) {
-          const did = web3.utils
-            .toChecksumAddress(data[i].datatokenId.address)
-            .replace('0x', 'did:op:')
-          const ddo = await retrieveDDO(did, cancelTokenSource.token)
-          if (!ddo) continue
-          if (ddo.service[1].type === 'access') {
-            filteredOrders.push({
-              ddo,
-              networkId: ddo.chainId,
-              dtSymbol: data[i].datatokenId.symbol,
-              timestamp: data[i].timestamp
-            })
-          }
-        }
-        const sortedOrders = filteredOrders.sort(
-          (a, b) => b.timestamp - a.timestamp
-        )
-        setOrders(sortedOrders)
-      } catch (err) {
-        Logger.log(err.message)
-      } finally {
-        setIsLoading(false)
-      }
-    }
-
-    filterAssets()
-
-    return () => {
-      cancelTokenSource.cancel()
-    }
-  }, [accountId, appConfig.metadataCacheUri, chainIds])
+  const { downloads, isDownloadsLoading } = useProfile()
 
   return accountId ? (
     <Table
       columns={columns}
-      data={orders}
+      data={downloads}
       paginationPerPage={10}
-      isLoading={isLoading}
+      isLoading={isDownloadsLoading}
     />
   ) : (
     <div>Please connect your Web3 wallet.</div>

--- a/src/components/pages/Profile/History/Downloads.tsx
+++ b/src/components/pages/Profile/History/Downloads.tsx
@@ -2,9 +2,9 @@ import React, { ReactElement } from 'react'
 import Table from '../../../atoms/Table'
 import Time from '../../../atoms/Time'
 import AssetTitle from '../../../molecules/AssetListTitle'
-import { DownloadedAsset } from '../../../../utils/subgraph'
 import NetworkName from '../../../atoms/NetworkName'
 import { useProfile } from '../../../../providers/Profile'
+import { DownloadedAsset } from '../../../../utils/aquarius'
 
 const columns = [
   {

--- a/src/providers/Profile.tsx
+++ b/src/providers/Profile.tsx
@@ -101,8 +101,10 @@ function ProfileProvider({
           links
         }
         setProfile(newProfile)
+        Logger.log('[profile] Found and set 3box profile.', newProfile)
       } else {
         setProfile(clearedProfile)
+        Logger.log('[profile] No 3box profile found.')
       }
     }
     getInfoFrom3Box()
@@ -124,10 +126,14 @@ function ProfileProvider({
 
     try {
       setIsPoolSharesLoading(true)
-      const data = await getPoolSharesData(accountId, chainIds)
-      setPoolShares(data)
+      const poolShares = await getPoolSharesData(accountId, chainIds)
+      setPoolShares(poolShares)
+      Logger.log(
+        `[profile] Fetched ${poolShares.length} pool shares.`,
+        poolShares
+      )
     } catch (error) {
-      console.error('Error fetching pool shares: ', error.message)
+      Logger.error('Error fetching pool shares: ', error.message)
     } finally {
       setIsPoolSharesLoading(false)
     }
@@ -171,6 +177,10 @@ function ProfileProvider({
         )
         setAssets(result.results)
         setAssetsTotal(result.totalResults)
+        Logger.log(
+          `[profile] Fetched ${result.totalResults} assets.`,
+          result.results
+        )
 
         // Hint: this would only make sense if we "search" in all subcomponents
         // against this provider's state, meaning filtering via js rather then sending
@@ -218,6 +228,10 @@ function ProfileProvider({
       )
       setDownloads(downloads)
       setDownloadsTotal(downloads.length)
+      Logger.log(
+        `[profile] Fetched ${downloads.length} download orders.`,
+        downloads
+      )
     },
     [accountId, chainIds]
   )

--- a/src/providers/Profile.tsx
+++ b/src/providers/Profile.tsx
@@ -203,10 +203,9 @@ function ProfileProvider({
       const didList: string[] = []
       const tokenOrders = await getUserTokenOrders(accountId, chainIds)
 
-      if (!tokenOrders) return
       for (let i = 0; i < tokenOrders?.length; i++) {
         const did = web3.utils
-          .toChecksumAddress(tokenOrders[i]?.datatokenId.address)
+          .toChecksumAddress(tokenOrders[i].datatokenId.address)
           .replace('0x', 'did:op:')
         didList.push(did)
       }

--- a/src/utils/aquarius.ts
+++ b/src/utils/aquarius.ts
@@ -256,12 +256,16 @@ export async function getAssetsFromDidList(
   cancelToken: CancelToken
 ): Promise<QueryResult> {
   try {
+    // TODO: figure out cleaner way to transform string[] into csv
     const searchDids = JSON.stringify(didList)
       .replace(/,/g, ' ')
       .replace(/"/g, '')
       .replace(/(\[|\])/g, '')
       // for whatever reason ddo.id is not searchable, so use ddo.dataToken instead
       .replace(/(did:op:)/g, '0x')
+
+    // safeguard against passed empty didList, preventing 500 from Aquarius
+    if (!searchDids) return
 
     const query = {
       page: 1,

--- a/src/utils/aquarius.ts
+++ b/src/utils/aquarius.ts
@@ -250,14 +250,11 @@ export async function getPublishedAssets(
   }
 }
 
-export async function getDownloadAssets(
+export async function getAssetsFromDidList(
   didList: string[],
-  tokenOrders: OrdersData[],
   chainIds: number[],
   cancelToken: CancelToken
-): Promise<DownloadedAsset[]> {
-  const downloadedAssets: DownloadedAsset[] = []
-
+): Promise<QueryResult> {
   try {
     const searchDids = JSON.stringify(didList)
       .replace(/,/g, ' ')
@@ -266,7 +263,7 @@ export async function getDownloadAssets(
       // for whatever reason ddo.id is not searchable, so use ddo.dataToken instead
       .replace(/(did:op:)/g, '0x')
 
-    const queryDownloads = {
+    const query = {
       page: 1,
       offset: 100,
       query: {
@@ -281,7 +278,27 @@ export async function getDownloadAssets(
       sort: { created: -1 }
     }
 
-    const queryResult = await queryMetadata(queryDownloads, cancelToken)
+    const queryResult = await queryMetadata(query, cancelToken)
+    return queryResult
+  } catch (error) {
+    Logger.error(error.message)
+  }
+}
+
+export async function getDownloadAssets(
+  didList: string[],
+  tokenOrders: OrdersData[],
+  chainIds: number[],
+  cancelToken: CancelToken
+): Promise<DownloadedAsset[]> {
+  const downloadedAssets: DownloadedAsset[] = []
+
+  try {
+    const queryResult = await getAssetsFromDidList(
+      didList,
+      chainIds,
+      cancelToken
+    )
     const ddoList = queryResult?.results
 
     for (let i = 0; i < ddoList?.length; i++) {

--- a/src/utils/aquarius.ts
+++ b/src/utils/aquarius.ts
@@ -265,7 +265,7 @@ export async function getAssetsFromDidList(
 
     const query = {
       page: 1,
-      offset: 100,
+      offset: 1000,
       query: {
         query_string: {
           query: `(${searchDids}) AND (${transformChainIdsListToQuery(
@@ -302,12 +302,18 @@ export async function getDownloadAssets(
     const ddoList = queryResult?.results
 
     for (let i = 0; i < ddoList?.length; i++) {
-      if (ddoList[i]?.service[1].type === 'access') {
+      if (ddoList[i].service[1].type === 'access') {
+        const tokenOrder = tokenOrders.filter(
+          (order) =>
+            order.datatokenId.address.toLowerCase() ===
+            ddoList[i].dataToken.toLowerCase()
+        )
+
         downloadedAssets.push({
           ddo: ddoList[i],
-          networkId: ddoList[i]?.chainId,
-          dtSymbol: tokenOrders[i]?.datatokenId.symbol,
-          timestamp: tokenOrders[i]?.timestamp
+          networkId: ddoList[i].chainId,
+          dtSymbol: tokenOrder[0].datatokenId.symbol,
+          timestamp: tokenOrder[0].timestamp
         })
       }
     }

--- a/src/utils/aquarius.ts
+++ b/src/utils/aquarius.ts
@@ -301,21 +301,22 @@ export async function getDownloadAssets(
     )
     const ddoList = queryResult?.results
 
-    for (let i = 0; i < ddoList?.length; i++) {
-      if (ddoList[i].service[1].type === 'access') {
-        const tokenOrder = tokenOrders.filter(
-          (order) =>
-            order.datatokenId.address.toLowerCase() ===
-            ddoList[i].dataToken.toLowerCase()
-        )
+    for (let i = 0; i < tokenOrders?.length; i++) {
+      const ddo = ddoList.filter(
+        (ddo) =>
+          tokenOrders[i].datatokenId.address.toLowerCase() ===
+          ddo.dataToken.toLowerCase()
+      )[0]
 
-        downloadedAssets.push({
-          ddo: ddoList[i],
-          networkId: ddoList[i].chainId,
-          dtSymbol: tokenOrder[0].datatokenId.symbol,
-          timestamp: tokenOrder[0].timestamp
-        })
-      }
+      // make sure we are only pushing download orders
+      if (ddo.service[1].type !== 'access') continue
+
+      downloadedAssets.push({
+        ddo,
+        networkId: ddo.chainId,
+        dtSymbol: tokenOrders[i].datatokenId.symbol,
+        timestamp: tokenOrders[i].timestamp
+      })
     }
 
     const sortedOrders = downloadedAssets.sort(

--- a/src/utils/subgraph.ts
+++ b/src/utils/subgraph.ts
@@ -25,9 +25,7 @@ import {
   PoolShares_poolShares as PoolShare
 } from '../@types/apollo/PoolShares'
 import { BestPrice } from '../models/BestPrice'
-import { CancelToken } from 'axios'
 import { OrdersData_tokenOrders as OrdersData } from '../@types/apollo/OrdersData'
-import { retrieveDDO } from './aquarius'
 
 export interface UserLiquidity {
   price: string
@@ -45,13 +43,6 @@ export interface AssetListPrices {
 
 interface DidAndDatatokenMap {
   [name: string]: string
-}
-
-export interface DownloadedAsset {
-  dtSymbol: string
-  timestamp: number
-  networkId: number
-  ddo: DDO
 }
 
 const FreeQuery = gql`
@@ -706,47 +697,27 @@ export async function getPoolSharesData(
   return data
 }
 
-export async function getDownloads(
+export async function getUserTokenOrders(
   accountId: string,
-  chainIds: number[],
-  cancelToken: CancelToken
-): Promise<DownloadedAsset[]> {
+  chainIds: number[]
+): Promise<OrdersData[]> {
+  const data: OrdersData[] = []
   const variables = { user: accountId?.toLowerCase() }
-  const filteredOrders: DownloadedAsset[] = []
 
   try {
-    const response = await fetchDataForMultipleChains(
+    const tokenOrders = await fetchDataForMultipleChains(
       UserTokenOrders,
       variables,
       chainIds
     )
 
-    const data: OrdersData[] = []
-    for (let i = 0; i < response.length; i++) {
-      response[i].tokenOrders.forEach((tokenOrder: OrdersData) => {
+    for (let i = 0; i < tokenOrders?.length; i++) {
+      tokenOrders[i]?.tokenOrders.forEach((tokenOrder: OrdersData) => {
         data.push(tokenOrder)
       })
     }
 
-    for (let i = 0; i < data.length; i++) {
-      const did = web3.utils
-        .toChecksumAddress(data[i].datatokenId.address)
-        .replace('0x', 'did:op:')
-      const ddo = await retrieveDDO(did, cancelToken)
-      if (!ddo) continue
-      if (ddo.service[1].type === 'access') {
-        filteredOrders.push({
-          ddo,
-          networkId: ddo.chainId,
-          dtSymbol: data[i].datatokenId.symbol,
-          timestamp: data[i].timestamp
-        })
-      }
-    }
-    const sortedOrders = filteredOrders.sort(
-      (a, b) => b.timestamp - a.timestamp
-    )
-    return sortedOrders
+    return data
   } catch (error) {
     Logger.error(error.message)
   }

--- a/src/utils/subgraph.ts
+++ b/src/utils/subgraph.ts
@@ -712,7 +712,7 @@ export async function getUserTokenOrders(
     )
 
     for (let i = 0; i < tokenOrders?.length; i++) {
-      tokenOrders[i]?.tokenOrders.forEach((tokenOrder: OrdersData) => {
+      tokenOrders[i].tokenOrders.forEach((tokenOrder: OrdersData) => {
         data.push(tokenOrder)
       })
     }


### PR DESCRIPTION
Add new stats number for total downloads account has done. All fetching for it centralized in `ProfileProvider` so as a bonus clicking on _Downloads_ tab is instant as data was alreeady fetched in background.

<img width="688" alt="Screen Shot 2021-09-09 at 17 28 16" src="https://user-images.githubusercontent.com/90316/132715772-18d14d3c-f8a3-47e1-96cd-54fcfecb8997.png">

So those individual `retieveDDO()` became really irresponsible so also addressed what's described in #842, replacing multiple retrieveDDO for each row with one single request. The helper methods for this then can be used to solve #842 too