### PR TITLE
Fix liquidity in own assets and sales broken statistics on network switching 

### DIFF
--- a/src/components/pages/Profile/Header/Stats.tsx
+++ b/src/components/pages/Profile/Header/Stats.tsx
@@ -59,7 +59,7 @@ export default function Stats({
       }
     }
     getSales()
-  }, [accountId, chainIds, assets])
+  }, [accountId, assets])
 
   useEffect(() => {
     if (!assets || !accountId || !chainIds) return
@@ -84,7 +84,7 @@ export default function Stats({
       }
     }
     getPublisherLiquidity()
-  }, [assets, accountId, chainIds])
+  }, [assets, accountId])
 
   useEffect(() => {
     if (!poolShares) return


### PR DESCRIPTION
Fixes #852 .

Changes proposed in this PR:

- removed `chainId` as a dependency on `useEffect()` used for number of **sales** and the **liquidity in own assets** statistics since we already have there the user assets dependency and the values should change only when the published assets is changed.
