### PR TITLE
Fix/ Issue872 search breaks page filter combo

### DIFF
--- a/src/components/templates/Search/index.tsx
+++ b/src/components/templates/Search/index.tsx
@@ -35,20 +35,32 @@ export default function SearchPage({
     sortOrder as string
   )
 
+  async function fetchAssets() {
+    setLoading(true)
+    setTotalResults(undefined)
+    const queryResult = await getResults(
+      parsed,
+      appConfig.metadataCacheUri,
+      chainIds
+    )
+    setQueryResult(queryResult)
+    setTotalResults(queryResult.totalResults)
+    setTotalPagesNumber(queryResult.totalPages)
+    setLoading(false)
+  }
+
+  useEffect(() => {
+    if (page !== '1') {
+      setPage(1)
+    } else {
+      fetchAssets()
+    }
+  }, [serviceType, accessType])
+
   useEffect(() => {
     if (!appConfig.metadataCacheUri) return
     async function initSearch() {
-      setLoading(true)
-      setTotalResults(undefined)
-      const queryResult = await getResults(
-        parsed,
-        appConfig.metadataCacheUri,
-        chainIds
-      )
-      setQueryResult(queryResult)
-      setTotalResults(queryResult.totalResults)
-      setTotalPagesNumber(queryResult.totalPages)
-      setLoading(false)
+      await fetchAssets()
     }
     initSearch()
   }, [
@@ -57,8 +69,6 @@ export default function SearchPage({
     tags,
     sort,
     page,
-    serviceType,
-    accessType,
     sortOrder,
     appConfig.metadataCacheUri,
     chainIds

--- a/src/components/templates/Search/index.tsx
+++ b/src/components/templates/Search/index.tsx
@@ -49,13 +49,14 @@ export default function SearchPage({
     setLoading(false)
   }
 
-  useEffect(() => {
-    if (page !== '1') {
-      setPage(1)
-    } else {
-      fetchAssets()
-    }
-  }, [serviceType, accessType])
+  function setPage(page: number) {
+    const newUrl = updateQueryStringParameter(
+      location.pathname + location.search,
+      'page',
+      `${page}`
+    )
+    return navigate(newUrl)
+  }
 
   useEffect(() => {
     if (!appConfig.metadataCacheUri) return
@@ -74,14 +75,13 @@ export default function SearchPage({
     chainIds
   ])
 
-  function setPage(page: number) {
-    const newUrl = updateQueryStringParameter(
-      location.pathname + location.search,
-      'page',
-      `${page}`
-    )
-    return navigate(newUrl)
-  }
+  useEffect(() => {
+    if (page !== '1') {
+      setPage(1)
+    } else {
+      fetchAssets()
+    }
+  }, [serviceType, accessType])
 
   return (
     <Permission eventType="browse">


### PR DESCRIPTION
Fixes #872 .

Changes proposed in this PR:

- set page to 1 when filters are applied on search results
