### PR TITLE
Data assets not updating properly when selected networks are changed in home page

### DIFF
--- a/src/components/pages/Home.tsx
+++ b/src/components/pages/Home.tsx
@@ -67,7 +67,6 @@ function SectionQueryResult({
   action?: ReactElement
   queryData?: string
 }) {
-  const { appConfig } = useSiteMetadata()
   const { chainIds } = useUserPreferences()
   const [result, setResult] = useState<any>()
   const [loading, setLoading] = useState<boolean>()

--- a/src/components/pages/Home.tsx
+++ b/src/components/pages/Home.tsx
@@ -74,8 +74,6 @@ function SectionQueryResult({
   const isMounted = useIsMounted()
   const newCancelToken = useCancelToken()
   useEffect(() => {
-    if (!appConfig.metadataCacheUri) return
-
     async function init() {
       if (chainIds.length === 0) {
         const result: any = {
@@ -107,12 +105,9 @@ function SectionQueryResult({
     }
     init()
   }, [
-    appConfig.metadataCacheUri,
-    chainIds.length,
     isMounted,
     newCancelToken,
-    query,
-    queryData
+    query
   ])
 
   return (

--- a/src/components/pages/Home.tsx
+++ b/src/components/pages/Home.tsx
@@ -104,11 +104,7 @@ function SectionQueryResult({
       }
     }
     init()
-  }, [
-    isMounted,
-    newCancelToken,
-    query
-  ])
+  }, [isMounted, newCancelToken, query])
 
   return (
     <section className={styles.section}>


### PR DESCRIPTION
Fixes #887.

How to reproduce:
have ETH and Rinkeby networks selected and then deselect ETH. You should still have assets from ETH network