### PR TITLE
Fix: website crashes on rinkeby search

### DIFF
--- a/src/components/molecules/AssetTeaser.tsx
+++ b/src/components/molecules/AssetTeaser.tsx
@@ -50,7 +50,7 @@ const AssetTeaser: React.FC<AssetTeaserProps> = ({
         <div className={styles.content}>
           <Dotdotdot tagName="p" clamp={3}>
             {removeMarkdown(
-              attributes?.additionalInformation?.description.substring(
+              attributes?.additionalInformation?.description?.substring(
                 0,
                 300
               ) || ''


### PR DESCRIPTION
Closes: #901 

Changes proposed in this PR:

- Using optional chaining on the description to stop the market crashing when there is an asset without a description (this happens sometimes on test nets) 