### PR TITLE
Fix config = undefined error in advanced publish settings

### DIFF
--- a/src/components/molecules/FormFields/AdvancedSettings.tsx
+++ b/src/components/molecules/FormFields/AdvancedSettings.tsx
@@ -33,21 +33,21 @@ export default function AdvancedSettings(prop: {
           Advanced Settings
         </Button>
       )}
-      {prop.content.data.map(
-        (field: FormFieldProps) =>
-          advancedSettings === true &&
-          field.advanced === true && (
-            <Field
-              key={field.name}
-              {...field}
-              options={field.options}
-              component={Input}
-              onChange={(e: ChangeEvent<HTMLInputElement>) =>
-                prop.handleFieldChange(e, field)
-              }
-            />
-          )
-      )}
+      {advancedSettings === true &&
+        prop.content.data.map(
+          (field: FormFieldProps) =>
+            field.advanced === true && (
+              <Field
+                key={field.name}
+                {...field}
+                options={field.options}
+                component={Input}
+                onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                  prop.handleFieldChange(e, field)
+                }
+              />
+            )
+        )}
     </>
   )
 }

--- a/src/components/molecules/FormFields/CustomProvider.tsx
+++ b/src/components/molecules/FormFields/CustomProvider.tsx
@@ -36,7 +36,7 @@ export default function CustomProvider(props: InputProps): ReactElement {
 
   useEffect(() => {
     loadProvider()
-  }, [providerUrl, config.providerUri])
+  }, [providerUrl, config?.providerUri])
 
   async function handleButtonClick(e: React.SyntheticEvent, url: string) {
     helpers.setTouched(false)


### PR DESCRIPTION
Fixes #914 .

Changes proposed in this PR:

- Added optional chaining to `CustomProvider.tsx` to handle `useOcean().config = undefined`
- Moved advancedSettings check in `AdvancedSettings.tsx` outside of `map` function