### PR TITLE
Remove ocean.provider.isValidUrl dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -108,6 +108,7 @@
       }
     },
     "../ocean.js": {
+      "name": "@oceanprotocol/lib",
       "version": "1.0.0-alpha",
       "license": "Apache-2.0",
       "dependencies": {

--- a/src/components/@shared/FormFields/Provider/index.tsx
+++ b/src/components/@shared/FormFields/Provider/index.tsx
@@ -1,24 +1,23 @@
 import React, { ReactElement, useState } from 'react'
 import { ErrorMessage, useField } from 'formik'
 import UrlInput from '../URLInput'
-import { useOcean } from '@context/Ocean'
 import { InputProps } from '@shared/FormInput'
 import FileInfo from '../FilesInput/Info'
 import styles from './index.module.css'
 import Button from '@shared/atoms/Button'
 import { initialValues } from 'src/components/Publish/_constants'
+import { isValidProvider } from '@utils/provider'
 
 export default function CustomProvider(props: InputProps): ReactElement {
   const [field, meta, helpers] = useField(props.name)
   const [isLoading, setIsLoading] = useState(false)
-  const { ocean, config } = useOcean()
 
   async function validateProvider(url: string) {
     setIsLoading(true)
 
     try {
       // TODO: #948 Remove ocean.provider.isValidProvider dependency.
-      const isValid = await ocean.provider.isValidProvider(url)
+      const isValid = await isValidProvider(url)
       helpers.setValue({ url, valid: isValid })
       helpers.setError(undefined)
     } catch (error) {


### PR DESCRIPTION
Fixes #948  .

Changes proposed in this PR:

- removed ocean.provider.isValidUrl() dependency
- used new isValidUrl provider function

