### PR TITLE
Test runs against Node.js v16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        node: ['15', '14'] # Latest + LTS
+        node: ['16', '14']
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
We have v16 defined in our `.nvmrc` so we should use it to test against. Keeping v14 runs too, as this is the version our build tools like Vercel use.