### PR TITLE
Pool tab refactor

### DIFF
--- a/src/@utils/subgraph.ts
+++ b/src/@utils/subgraph.ts
@@ -830,7 +830,7 @@ export async function getPoolData(
     queryVariables,
     getQueryContext(chainId)
   )
-  return response?.data.pool
+  return response?.data?.pool
 }
 
 export async function getUserPoolShareBalance(
@@ -847,5 +847,5 @@ export async function getUserPoolShareBalance(
     queryVariables,
     getQueryContext(chainId)
   )
-  return response?.data.pool.shares[0]?.shares || '0'
+  return response?.data?.pool?.shares[0]?.shares || '0'
 }

--- a/src/components/Asset/AssetActions/AssetActionHistoryTable.module.css
+++ b/src/components/Asset/AssetActions/AssetActionHistoryTable.module.css
@@ -1,5 +1,5 @@
 .actions {
-  /* composes: container from './AssetActions/Pool/index.module.css'; */
+  composes: container from './Pool/index.module.css';
   border-top: 1px solid var(--border-color);
   margin-top: calc(var(--spacer) / 1.5);
   padding: calc(var(--spacer) / 1.5);
@@ -12,7 +12,7 @@
 }
 
 .title {
-  /* composes: title from './AssetActions/Pool/index.module.css'; */
+  composes: title from './Pool/index.module.css';
   margin-bottom: 0;
   display: flex;
   align-items: center;

--- a/src/components/Asset/AssetActions/Pool/Add/index.tsx
+++ b/src/components/Asset/AssetActions/Pool/Add/index.tsx
@@ -25,7 +25,6 @@ const initialValues: FormAddLiquidity = {
 
 export default function Add({
   setShowAdd,
-  refreshInfo,
   poolAddress,
   totalPoolTokens,
   totalBalance,
@@ -34,7 +33,6 @@ export default function Add({
   dtAddress
 }: {
   setShowAdd: (show: boolean) => void
-  refreshInfo: () => void
   poolAddress: string
   totalPoolTokens: string
   totalBalance: PoolBalance
@@ -113,7 +111,6 @@ export default function Add({
       //     : await ocean.pool.addDTLiquidity(accountId, poolAddress, `${amount}`)
       // setTxId(result?.transactionHash)
       // resetForm()
-      // refreshInfo()
     } catch (error) {
       console.error(error.message)
       toast.error(error.message)

--- a/src/components/Asset/AssetActions/Pool/Add/index.tsx
+++ b/src/components/Asset/AssetActions/Pool/Add/index.tsx
@@ -31,7 +31,7 @@ export default function Add({
   swapFee,
   dtSymbol,
   dtAddress,
-  refreshAllLiquidity
+  fetchAllData
 }: {
   setShowAdd: (show: boolean) => void
   poolAddress: string
@@ -40,7 +40,7 @@ export default function Add({
   swapFee: string
   dtSymbol: string
   dtAddress: string
-  refreshAllLiquidity: () => void
+  fetchAllData: () => void
 }): ReactElement {
   const { accountId, balance, web3 } = useWeb3()
   const { isAssetNetwork } = useAsset()
@@ -76,7 +76,7 @@ export default function Add({
       setDtBalance(dtBalance)
     }
     getDtBalance()
-  }, [web3, accountId, dtAddress, coin])
+  }, [web3, accountId, dtAddress, coin, isAssetNetwork])
 
   // Get maximum amount for either OCEAN or datatoken
   useEffect(() => {
@@ -113,7 +113,7 @@ export default function Add({
       //     : await ocean.pool.addDTLiquidity(accountId, poolAddress, `${amount}`)
       // setTxId(result?.transactionHash)
       // resetForm()
-      refreshAllLiquidity()
+      fetchAllData()
     } catch (error) {
       console.error(error.message)
       toast.error(error.message)

--- a/src/components/Asset/AssetActions/Pool/Add/index.tsx
+++ b/src/components/Asset/AssetActions/Pool/Add/index.tsx
@@ -30,7 +30,8 @@ export default function Add({
   totalBalance,
   swapFee,
   dtSymbol,
-  dtAddress
+  dtAddress,
+  refreshAllLiquidity
 }: {
   setShowAdd: (show: boolean) => void
   poolAddress: string
@@ -39,6 +40,7 @@ export default function Add({
   swapFee: string
   dtSymbol: string
   dtAddress: string
+  refreshAllLiquidity: () => void
 }): ReactElement {
   const { accountId, balance, web3 } = useWeb3()
   const { isAssetNetwork } = useAsset()
@@ -111,6 +113,7 @@ export default function Add({
       //     : await ocean.pool.addDTLiquidity(accountId, poolAddress, `${amount}`)
       // setTxId(result?.transactionHash)
       // resetForm()
+      refreshAllLiquidity()
     } catch (error) {
       console.error(error.message)
       toast.error(error.message)

--- a/src/components/Asset/AssetActions/Pool/Remove.tsx
+++ b/src/components/Asset/AssetActions/Pool/Remove.tsx
@@ -29,14 +29,14 @@ export default function Remove({
   poolTokens,
   totalPoolTokens,
   dtSymbol,
-  refreshAllLiquidity
+  fetchAllData
 }: {
   setShowRemove: (show: boolean) => void
   poolAddress: string
   poolTokens: string
   totalPoolTokens: string
   dtSymbol: string
-  refreshAllLiquidity: () => void
+  fetchAllData: () => void
 }): ReactElement {
   const slippagePresets = ['5', '10', '15', '25', '50']
   const { accountId } = useWeb3()
@@ -74,7 +74,7 @@ export default function Remove({
       //         minOceanAmount
       //       )
       // setTxId(result?.transactionHash)
-      refreshAllLiquidity()
+      fetchAllData()
     } catch (error) {
       LoggerInstance.error(error.message)
       toast.error(error.message)

--- a/src/components/Asset/AssetActions/Pool/Remove.tsx
+++ b/src/components/Asset/AssetActions/Pool/Remove.tsx
@@ -28,13 +28,15 @@ export default function Remove({
   poolAddress,
   poolTokens,
   totalPoolTokens,
-  dtSymbol
+  dtSymbol,
+  refreshAllLiquidity
 }: {
   setShowRemove: (show: boolean) => void
   poolAddress: string
   poolTokens: string
   totalPoolTokens: string
   dtSymbol: string
+  refreshAllLiquidity: () => void
 }): ReactElement {
   const slippagePresets = ['5', '10', '15', '25', '50']
   const { accountId } = useWeb3()
@@ -72,6 +74,7 @@ export default function Remove({
       //         minOceanAmount
       //       )
       // setTxId(result?.transactionHash)
+      refreshAllLiquidity()
     } catch (error) {
       LoggerInstance.error(error.message)
       toast.error(error.message)

--- a/src/components/Asset/AssetActions/Pool/Remove.tsx
+++ b/src/components/Asset/AssetActions/Pool/Remove.tsx
@@ -25,14 +25,12 @@ import content from '../../../../../content/price.json'
 
 export default function Remove({
   setShowRemove,
-  refreshInfo,
   poolAddress,
   poolTokens,
   totalPoolTokens,
   dtSymbol
 }: {
   setShowRemove: (show: boolean) => void
-  refreshInfo: () => void
   poolAddress: string
   poolTokens: string
   totalPoolTokens: string
@@ -74,7 +72,6 @@ export default function Remove({
       //         minOceanAmount
       //       )
       // setTxId(result?.transactionHash)
-      // refreshInfo()
     } catch (error) {
       LoggerInstance.error(error.message)
       toast.error(error.message)

--- a/src/components/Asset/AssetActions/Pool/index.tsx
+++ b/src/components/Asset/AssetActions/Pool/index.tsx
@@ -100,7 +100,7 @@ export default function Pool(): ReactElement {
   }, [ddo?.chainId, price?.address, accountId])
 
   // Helper: fetch everything
-  const refreshAllLiquidity = useCallback(() => {
+  const fetchAllData = useCallback(() => {
     fetchPoolData()
     fetchUserShares()
   }, [fetchPoolData, fetchUserShares])
@@ -110,13 +110,13 @@ export default function Pool(): ReactElement {
     if (fetchInterval) return
 
     const newInterval = setInterval(() => {
-      refreshAllLiquidity()
+      fetchAllData()
       LoggerInstance.log(
         `[pool] Refetch interval fired after ${refreshInterval / 1000}s`
       )
     }, refreshInterval)
     setFetchInterval(newInterval)
-  }, [fetchInterval, refreshAllLiquidity, refreshInterval])
+  }, [fetchInterval, fetchAllData, refreshInterval])
 
   useEffect(() => {
     return () => {
@@ -125,14 +125,14 @@ export default function Pool(): ReactElement {
   }, [fetchInterval])
 
   //
-  // 0 Fetch all the data
+  // 0 Fetch all the data on mount
   // All further effects depend on the fetched data
   // and only do further data checking and manipulation.
   //
   useEffect(() => {
-    refreshAllLiquidity()
+    fetchAllData()
     initFetchInterval()
-  }, [refreshAllLiquidity, initFetchInterval])
+  }, [fetchAllData, initFetchInterval])
 
   //
   // 1 General Pool Info
@@ -345,7 +345,7 @@ export default function Pool(): ReactElement {
           swapFee={poolInfo.poolFee}
           dtSymbol={poolInfo.dtSymbol}
           dtAddress={ddo?.services[0].datatokenAddress}
-          refreshAllLiquidity={refreshAllLiquidity}
+          fetchAllData={fetchAllData}
         />
       ) : showRemove ? (
         <Remove
@@ -354,7 +354,7 @@ export default function Pool(): ReactElement {
           poolTokens={poolInfoUser.poolShares}
           totalPoolTokens={poolInfo?.totalPoolTokens}
           dtSymbol={poolInfo?.dtSymbol}
-          refreshAllLiquidity={refreshAllLiquidity}
+          fetchAllData={fetchAllData}
         />
       ) : (
         <>

--- a/src/components/Asset/AssetActions/Pool/index.tsx
+++ b/src/components/Asset/AssetActions/Pool/index.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement, useCallback, useEffect, useState } from 'react'
-import { Logger, LoggerInstance } from '@oceanprotocol/lib'
+import { LoggerInstance } from '@oceanprotocol/lib'
 import styles from './index.module.css'
 import stylesActions from './Actions.module.css'
 import PriceUnit from '@shared/Price/PriceUnit'
@@ -105,17 +105,15 @@ export default function Pool(): ReactElement {
   const { isInPurgatory, ddo, owner, price, refreshInterval, isAssetNetwork } =
     useAsset()
 
-  const [dtSymbol, setDtSymbol] = useState<string>()
-  const [oceanSymbol, setOceanSymbol] = useState<string>()
-
-  const [userShares, setUserShares] = useState<string>()
-  const [totalPoolTokens, setTotalPoolTokens] = useState<string>()
-
   const [poolData, setPoolData] = useState<PoolLiquidityData>()
   const [poolFee, setPoolFee] = useState<string>()
   const [weightOcean, setWeightOcean] = useState<string>()
   const [weightDt, setWeightDt] = useState<string>()
+  const [dtSymbol, setDtSymbol] = useState<string>()
+  const [oceanSymbol, setOceanSymbol] = useState<string>()
+  const [totalPoolTokens, setTotalPoolTokens] = useState<string>()
 
+  const [userShares, setUserShares] = useState<string>()
   const [userLiquidity, setUserLiquidity] = useState<PoolBalance>()
   const [hasAddedLiquidity, setHasAddedLiquidity] = useState(false)
   const [poolShare, setPoolShare] = useState<string>()
@@ -145,7 +143,7 @@ export default function Pool(): ReactElement {
 
     const poolData = await getPoolData(ddo.chainId, price.address, owner)
     setPoolData(poolData)
-    LoggerInstance.log('[pool] Pool data', poolData)
+    LoggerInstance.log('[pool] Fetched pool data:', poolData)
   }, [ddo?.chainId, price?.address, owner])
 
   const fetchUserShares = useCallback(async () => {
@@ -157,7 +155,7 @@ export default function Pool(): ReactElement {
       accountId
     )
     setUserShares(userShares)
-    LoggerInstance.log(`[pool] User shares: ${userShares}`)
+    LoggerInstance.log(`[pool] Fetched user shares: ${userShares}`)
   }, [ddo?.chainId, price?.address, accountId])
 
   // Helper to fetch everything
@@ -172,6 +170,9 @@ export default function Pool(): ReactElement {
     const newInterval = setInterval(() => {
       fetchPoolData()
       fetchUserShares()
+      LoggerInstance.log(
+        `[pool] Refetch interval fired after ${refreshInterval / 1000}s`
+      )
     }, refreshInterval)
     setFetchInterval(newInterval)
   }, [fetchInterval, fetchPoolData, fetchUserShares, refreshInterval])


### PR DESCRIPTION
- Fixes #971
- Fixes #894

Refactor with the goal to make data fetching/manipulation more efficient and for developers making that massive `Pool/index.tsx` easier to understand. We always added stuff in there and it took me like 1 hour to figure what exactly is going on in there in terms of data dependencies and I initially created this 😀

- structure the effects more logically, split up data fetching & data checking/manipulation: 0 data fetching, 1 pool info, 2 creator info, 3 user info
- structure the state data the same way in nested state objects, unify them (`poolInfo`, `poolInfoOwner`, `poolInfoUser`)
- clean up and tweak all the effect dependencies
- rename swap fee to pool fee (that's what it is called in contracts/subgraph)
- remove that refetch hack thingy, use new structure for refetch after add/remove
- fix user transactions section styles
- fix user pool share display in case of no liquidity, just return and display `0` in that case
- more helpful logging mode of responses and transformed data:
  <img width="697" alt="Screen Shot 2022-01-19 at 16 56 03" src="https://user-images.githubusercontent.com/90316/150177779-98ae58d2-efe7-4fca-88e1-905820c3999b.png">

