### PR TITLE
Feature/seo

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -85,7 +85,9 @@ module.exports = {
       options: {
         sitemap: `${
           appConfig.metadataCacheUri
-        }/sitemap?base=${encodeURIComponent(siteContent.site.siteUrl)}`,
+        }/api/v1/aquarius/assets/sitemap?base=${encodeURIComponent(
+          siteContent.site.siteUrl
+        )}`,
         env: {
           development: {
             policy: [{ userAgent: '*', disallow: ['/'] }]

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -78,6 +78,23 @@ module.exports = {
         ...appConfig.darkModeConfig,
         minify: true
       }
+    },
+    'gatsby-plugin-robots-txt',
+    {
+      resolve: 'gatsby-plugin-robots-txt',
+      options: {
+        sitemap: `${
+          appConfig.metadataCacheUri
+        }/sitemap?base=${encodeURIComponent(siteContent.site.siteUrl)}`,
+        env: {
+          development: {
+            policy: [{ userAgent: '*', disallow: ['/'] }]
+          },
+          production: {
+            policy: [{ userAgent: '*', allow: '/' }]
+          }
+        }
+      }
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "gatsby-plugin-manifest": "^2.10.0",
     "gatsby-plugin-react-helmet": "^3.8.0",
     "gatsby-plugin-remove-trailing-slashes": "^2.8.0",
+    "gatsby-plugin-robots-txt": "^1.6.14",
     "gatsby-plugin-sharp": "^2.14.4",
     "gatsby-plugin-svgr": "^2.1.0",
     "gatsby-plugin-use-dark-mode": "^1.3.0",

--- a/src/components/atoms/Seo.tsx
+++ b/src/components/atoms/Seo.tsx
@@ -25,12 +25,6 @@ export default function Seo({
     >
       <html lang="en" />
 
-      {isBrowser &&
-        window.location &&
-        window.location.hostname !== 'oceanprotocol.com' && (
-          <meta name="robots" content="noindex,nofollow" />
-        )}
-
       <link rel="canonical" href={canonical} />
 
       <meta name="description" content={description} />

--- a/src/components/atoms/Seo.tsx
+++ b/src/components/atoms/Seo.tsx
@@ -6,11 +6,13 @@ import { isBrowser } from '../../utils'
 export default function Seo({
   title,
   description,
-  uri
+  uri,
+  metadescription
 }: {
   title?: string
   description?: string
   uri: string
+  metadescription: string
 }): ReactElement {
   const { siteTitle, siteTagline, siteUrl, siteImage } = useSiteMetadata()
 
@@ -27,9 +29,12 @@ export default function Seo({
 
       <link rel="canonical" href={canonical} />
 
-      <meta name="description" content={description} />
+      <meta name="description" content={metadescription || description} />
       <meta property="og:title" content={title} />
-      <meta property="og:description" content={description} />
+      <meta
+        property="og:description"
+        content={metadescription || description}
+      />
       <meta property="og:url" content={uri} />
 
       <meta

--- a/src/components/atoms/Seo.tsx
+++ b/src/components/atoms/Seo.tsx
@@ -42,7 +42,11 @@ export default function Seo({
       />
 
       <meta property="og:site_name" content={siteTitle} />
-      <meta name="twitter:creator" content="@oceanprotocol" />
+      {isBrowser &&
+        window.location &&
+        window.location.hostname == 'market.oceanprotocol.com' && (
+          <meta name="twitter:creator" content="@oceanprotocol" />
+        )}
       <meta name="twitter:card" content="summary_large_image" />
     </Helmet>
   )

--- a/src/components/templates/Page.tsx
+++ b/src/components/templates/Page.tsx
@@ -8,6 +8,7 @@ export interface PageProps {
   title?: string
   uri: string
   description?: string
+  metadescription?: string
   noPageHeader?: boolean
   headerCenter?: boolean
 }
@@ -17,12 +18,18 @@ export default function Page({
   title,
   uri,
   description,
+  metadescription,
   noPageHeader,
   headerCenter
 }: PageProps): ReactElement {
   return (
     <>
-      <Seo title={title} description={description} uri={uri} />
+      <Seo
+        title={title}
+        description={description}
+        metadescription={metadescription}
+        uri={uri}
+      />
       <Container>
         {title && !noPageHeader && (
           <PageHeader

--- a/src/components/templates/PageAssetDetails.tsx
+++ b/src/components/templates/PageAssetDetails.tsx
@@ -5,14 +5,19 @@ import Page from './Page'
 import Alert from '../atoms/Alert'
 import Loader from '../atoms/Loader'
 import { useAsset } from '../../providers/Asset'
+import removeMarkdown from 'remove-markdown'
 
 export default function PageTemplateAssetDetails({
   uri
 }: {
   uri: string
 }): ReactElement {
-  const { ddo, title, error, isInPurgatory, loading } = useAsset()
+  const { metadata, ddo, title, error, isInPurgatory, loading } = useAsset()
   const [pageTitle, setPageTitle] = useState<string>()
+
+  const metaDescription = removeMarkdown(
+    metadata?.additionalInformation?.description?.substring(0, 150) || ''
+  )
 
   useEffect(() => {
     if (!ddo || error) {
@@ -24,7 +29,7 @@ export default function PageTemplateAssetDetails({
   }, [ddo, error, isInPurgatory, title])
 
   return ddo && pageTitle !== undefined && !loading ? (
-    <Page title={pageTitle} uri={uri}>
+    <Page title={pageTitle} uri={uri} metadescription={metaDescription}>
       <Router basepath="/asset">
         <AssetContent path=":did" />
       </Router>


### PR DESCRIPTION
Fulfilment of [mPowered’s DAO, Round 13](https://port.oceanprotocol.com/t/round-13-improving-search-engine-discoverability-for-the-current-ocean-data-marketplace/1308) relating to search engine optimisations (SEO).

Changes:
- remove bug which adds noindex,nofollow meta tag to **ALL** pages, now search engines will crawl the market
- add a third party gatsby plugin which generates a `robot.txt` file on build with a sitemap
- add a meta description to every asset page, which comes from the first 150 characters of the description markdown
- only show the ocean twitter meta tag when in the ocean marketplace

Note:
This PR is dependant on a change to aquarius. The `robots.txt` file refers to a new endpoint which outputs an XML sitemap of all appropriate asset URLs. Please do not merge until the [feature/seo](https://github.com/oceanprotocol/aquarius/pull/677) branch is merged into aquarius and implemented in production.
