### PR TITLE
fix file info

### DIFF
--- a/src/@utils/provider.ts
+++ b/src/@utils/provider.ts
@@ -18,7 +18,24 @@ export async function getEncryptedFiles(
   }
 }
 
-export async function getFileInfo(
+export async function getFileDidInfo(
+  did: string,
+  serviceId: string,
+  providerUrl: string
+): Promise<FileMetadata[]> {
+  try {
+    const response = await ProviderInstance.checkDidFiles(
+      did,
+      serviceId as any, // TODO: why does ocean.js want a number here?
+      providerUrl
+    )
+    return response
+  } catch (error) {
+    LoggerInstance.error(error.message)
+  }
+}
+
+export async function getFileUrlInfo(
   url: string,
   providerUrl: string
 ): Promise<FileMetadata[]> {

--- a/src/components/@shared/FormFields/FilesInput/index.tsx
+++ b/src/components/@shared/FormFields/FilesInput/index.tsx
@@ -5,7 +5,7 @@ import FileInfo from './Info'
 import UrlInput from '../URLInput'
 import { InputProps } from '@shared/FormInput'
 import { initialValues } from 'src/components/Publish/_constants'
-import { getFileInfo } from '@utils/provider'
+import { getFileUrlInfo } from '@utils/provider'
 import { FormPublishData } from 'src/components/Publish/_types'
 
 export default function FilesInput(props: InputProps): ReactElement {
@@ -19,7 +19,7 @@ export default function FilesInput(props: InputProps): ReactElement {
     async function validateUrl() {
       try {
         setIsLoading(true)
-        const checkedFile = await getFileInfo(url, providerUri)
+        const checkedFile = await getFileUrlInfo(url, providerUri)
         checkedFile && helpers.setValue([{ url, ...checkedFile[0] }])
       } catch (error) {
         toast.error('Could not fetch file info. Please check URL and try again')

--- a/src/components/Asset/AssetActions/index.tsx
+++ b/src/components/Asset/AssetActions/index.tsx
@@ -9,7 +9,7 @@ import Trade from './Trade'
 import { useAsset } from '@context/Asset'
 import { useWeb3 } from '@context/Web3'
 import Web3Feedback from '@shared/Web3Feedback'
-import { getFileInfo } from '@utils/provider'
+import { getFileDidInfo, getFileUrlInfo } from '@utils/provider'
 import { getOceanConfig } from '@utils/ocean'
 import { useCancelToken } from '@hooks/useCancelToken'
 import { useIsMounted } from '@hooks/useIsMounted'
@@ -67,15 +67,18 @@ export default function AssetActions({
 
     async function initFileInfo() {
       setFileIsLoading(true)
-      const fileUrl =
-        formikState?.values?.services?.[0].files?.[0].url ||
-        (asset.metadata?.links ? asset.metadata?.links[0] : ' ')
       const providerUrl =
         formikState?.values?.services[0].providerUrl.url ||
-        oceanConfig.providerUri
+        asset?.services[0]?.serviceEndpoint
 
       try {
-        const fileInfoResponse = await getFileInfo(fileUrl, providerUrl)
+        const fileInfoResponse = formikState?.values?.services?.[0].files?.[0]
+          .url
+          ? await getFileUrlInfo(
+              formikState?.values?.services?.[0].files?.[0].url,
+              providerUrl
+            )
+          : await getFileDidInfo(asset?.id, asset?.services[0]?.id, providerUrl)
         fileInfoResponse && setFileMetadata(fileInfoResponse[0])
         setFileIsLoading(false)
       } catch (error) {


### PR DESCRIPTION
closes #1059

Multiple things:
- use different methods from ocean.js depending on if file to check is a URL or a DID, this really should be just one method in ocean.js detecting either DID or URL but that's what it is right now
- grab the `providerUrl` from the DDO service instead of ocean config
- reverts #1029 where I couldn't figure out anymore why we added the sample files, as we never display them with the file icon