### PR TITLE
Disable exhaustive-deps warning in Pool context

### DIFF
--- a/src/@context/Pool/index.tsx
+++ b/src/@context/Pool/index.tsx
@@ -77,8 +77,6 @@ function PoolProvider({ children }: { children: ReactNode }): ReactElement {
   }, [asset?.chainId, asset?.accessDetails?.addressOrId, owner, accountId])
 
   // Helper: start interval fetching
-  // Having `accountId` as dependency is important for interval to
-  // change after user account switch.
   const initFetchInterval = useCallback(() => {
     if (fetchInterval) return
 
@@ -89,6 +87,10 @@ function PoolProvider({ children }: { children: ReactNode }): ReactElement {
       )
     }, refreshInterval)
     setFetchInterval(newInterval)
+
+    // Having `accountId` as dependency is important for interval to
+    // change after user account switch.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [fetchInterval, fetchAllData, accountId])
 
   useEffect(() => {


### PR DESCRIPTION
Classical case of we know what we are doing™, as these warnings become very noisy in PR reviews.

Clearly stated with comment why it is disabled 