### PR TITLE
CI runs for v4 branch

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @mihaisc @kremalicious @claudiaHash @bogdanfazakas @KatunaNorbert @jamiehewitt15 @DimitarSD
+* @mihaisc @kremalicious @claudiaHash @bogdanfazakas @EnzoVezzaro

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - v4
     tags:
       - '**'
   pull_request:


### PR DESCRIPTION
Although `on.pull_request` should actually trigger our v4 branch builds with #928 open, it just doesn't for whatever reason so let's try `on.push` too. 

We only know after merge if it works.

Also, update code owners so add @EnzoVezzaro, and remove @KatunaNorbert and @jamiehewitt15 so they are not asked for review for each and every v4 PR on here as both their main focus currently is outside of v4 market.