### PR TITLE
change layout and align datatokens / nft view on mobile

### DIFF
--- a/src/components/@shared/FormFields/Datatoken/index.module.css
+++ b/src/components/@shared/FormFields/Datatoken/index.module.css
@@ -1,7 +1,8 @@
 .datatoken {
   display: grid;
   gap: var(--spacer);
-  grid-template-columns: 1fr 11fr;
+  grid-template-columns: none;
+  margin-top: var(--spacer);
   margin-bottom: var(--spacer);
   align-items: center;
 }
@@ -25,4 +26,11 @@
 .image svg {
   width: 100%;
   height: 100%;
+}
+
+@media (min-width: 40rem) {
+  .datatoken {
+    grid-template-columns: 1fr 11fr;
+    margin-top: 0;
+  }
 }

--- a/src/components/@shared/FormFields/Datatoken/index.module.css
+++ b/src/components/@shared/FormFields/Datatoken/index.module.css
@@ -2,7 +2,7 @@
   display: grid;
   gap: var(--spacer);
   grid-template-columns: none;
-  margin-top: var(--spacer);
+  margin-top: calc(var(--spacer) / 2);
   margin-bottom: var(--spacer);
   align-items: center;
 }
@@ -21,6 +21,7 @@
   border: 1px solid var(--border-color);
   fill: var(--brand-violet);
   border-radius: 50%;
+  margin: 0;
 }
 
 .image svg {
@@ -31,6 +32,5 @@
 @media (min-width: 40rem) {
   .datatoken {
     grid-template-columns: 1fr 11fr;
-    margin-top: 0;
   }
 }

--- a/src/components/@shared/FormFields/Nft/index.module.css
+++ b/src/components/@shared/FormFields/Nft/index.module.css
@@ -2,7 +2,7 @@
   display: grid;
   gap: var(--spacer);
   grid-template-columns: none;
-  margin-top: var(--spacer);
+  margin-top: calc(var(--spacer) / 2);
   margin-bottom: var(--spacer);
   align-items: center;
 }
@@ -20,6 +20,7 @@
   border-radius: var(--border-radius);
   border: 1px solid var(--border-color);
   position: relative;
+  margin: 0;
 }
 
 .refresh {
@@ -37,6 +38,5 @@
 @media (min-width: 40rem) {
   .nft {
     grid-template-columns: 1fr 11fr;
-    margin-top: 0;
   }
 }


### PR DESCRIPTION
Merged to [Mobile publish flow (layout)#1075](https://github.com/oceanprotocol/market/issues/1075).

Changes proposed in this PR:

- remove unnecessary margin around nft, datatoken UI
- align datatokens/nft view on publish widzard for mobile