### PR TITLE
fix search title

### DIFF
--- a/src/@types/aquarius/SearchResponse.d.ts
+++ b/src/@types/aquarius/SearchResponse.d.ts
@@ -20,7 +20,10 @@ interface SearchResponse {
   _scroll_id?: string | undefined
   _shards: ShardsResponse
   hits: {
-    total: number
+    total: {
+      relation: string
+      value: number
+    }
     max_score: number
     hits: Array<{
       _index: string

--- a/src/@utils/aquarius.ts
+++ b/src/@utils/aquarius.ts
@@ -79,7 +79,7 @@ export function transformQueryResult(
   result.results = (queryResult.hits.hits || []).map(
     (hit) => hit._source as Asset
   )
-  result.totalResults = queryResult.hits.total
+  result.totalResults = queryResult.hits.total.value
   result.totalPages =
     result.totalResults / size < 1
       ? Math.floor(result.totalResults / size)


### PR DESCRIPTION
closes #1113

Looks like Aquarius response for `queryResult.hits.total` changed slightly. Change should also make `totalPages` work again which in turn makes the pagination appear with more assets.