### PR TITLE
Bookmarks fixes

### DIFF
--- a/src/@utils/accessDetailsAndPricing.ts
+++ b/src/@utils/accessDetailsAndPricing.ts
@@ -334,12 +334,12 @@ export async function getAccessDetailsForAssets(
   for (const asset of assets) {
     if (chainAssetLists[asset.chainId]) {
       chainAssetLists[asset.chainId].push(
-        asset?.services[0].datatokenAddress.toLowerCase()
+        asset.services[0].datatokenAddress.toLowerCase()
       )
     } else {
       chainAssetLists[asset.chainId] = []
       chainAssetLists[asset.chainId].push(
-        asset?.services[0].datatokenAddress.toLowerCase()
+        asset.services[0].datatokenAddress.toLowerCase()
       )
     }
   }

--- a/src/@utils/aquarius.ts
+++ b/src/@utils/aquarius.ts
@@ -180,8 +180,9 @@ export async function retrieveDDOListByDIDs(
   chainIds: number[],
   cancelToken: CancelToken
 ): Promise<Asset[]> {
+  if (didList?.length === 0 || chainIds?.length === 0) return []
+
   try {
-    if (didList?.length === 0 || chainIds?.length === 0) return []
     const orderedDDOListByDIDList: Asset[] = []
     const baseQueryparams = {
       chainIds,
@@ -190,9 +191,10 @@ export async function retrieveDDOListByDIDs(
     } as BaseQueryParams
     const query = generateBaseQuery(baseQueryparams)
     const result = await queryMetadata(query, cancelToken)
+
     didList.forEach((did: string) => {
       const ddo = result.results.find((ddo: Asset) => ddo.id === did)
-      orderedDDOListByDIDList.push(ddo)
+      if (ddo) orderedDDOListByDIDList.push(ddo)
     })
     return orderedDDOListByDIDList
   } catch (error) {


### PR DESCRIPTION
Currently errors are thrown when user bookmarks have v3 DIDs, cause those DIDs are not in v4 Aquarius.

Make sure `retrieveDDOListByDIDs` returns empty array when no DDOs are found so all successive checks work correctly.

Moved out of #1123