### PR TITLE
remove unnecessary appearance on radio

### DIFF
--- a/src/components/@shared/FormInput/InputElement.module.css
+++ b/src/components/@shared/FormInput/InputElement.module.css
@@ -38,8 +38,6 @@
   color: var(--brand-grey-light);
   cursor: not-allowed;
   pointer-events: none;
-  /* for hiding spin buttons in Firefox */
-  -moz-appearance: textfield;
 }
 
 .input[readonly]::-webkit-inner-spin-button,


### PR DESCRIPTION
Fixes [Radio inputs have wrong color in Firefox#1130](https://github.com/oceanprotocol/market/issues/1130).

Changes proposed in this PR:

- remove unnecessary appearance CSS property