### PR TITLE
stop execution on publish if user rejects approval tokens

### DIFF
--- a/src/components/Publish/_utils.ts
+++ b/src/components/Publish/_utils.ts
@@ -260,6 +260,12 @@ export async function createTokensAndPricing(
       )
       LoggerInstance.log('[publish] pool.approve tx', txApprove, nftFactory)
 
+      if (!txApprove) {
+        throw new Error(
+          'MetaMask Approve TX Signature: User denied transaction signature'
+        )
+      }
+
       const result = await nftFactory.createNftErc20WithPool(
         accountId,
         nftCreateData,


### PR DESCRIPTION
Fixes [if an user rejects the approval of the spender, the transaction doesn't get restore again #1106](https://github.com/oceanprotocol/market/issues/1106).

Changes proposed in this PR:

- catch user rejection on token approval 