### PR TITLE
Feature/issue 1175 catch user rejection buy

### DIFF
--- a/src/@utils/order.ts
+++ b/src/@utils/order.ts
@@ -60,6 +60,9 @@ export async function order(
         orderPriceAndFees.price,
         false
       )
+      if (!txApprove) {
+        return
+      }
 
       const freParams = {
         exchangeContract: config.fixedRateExchangeAddress,

--- a/src/@utils/pool.ts
+++ b/src/@utils/pool.ts
@@ -56,6 +56,9 @@ export async function buyDtFromPool(
     dtPrice.tokenAmount,
     false
   )
+  if (!approveTx) {
+    return
+  }
   const result = await pool.swapExactAmountOut(
     accountId,
     accessDetails.addressOrId,

--- a/src/components/Asset/AssetActions/Download.tsx
+++ b/src/components/Asset/AssetActions/Download.tsx
@@ -146,9 +146,7 @@ export default function Download({
               asset.accessDetails.datatoken?.symbol
             )[0]
           )
-
           const tx = await buyDtFromPool(asset.accessDetails, accountId, web3)
-
           if (!tx) {
             toast.error('Failed to buy datatoken from pool!')
             setIsLoading(false)
@@ -162,7 +160,11 @@ export default function Download({
           )[asset.accessDetails?.type === 'fixed' ? 2 : 1]
         )
         const orderTx = await order(web3, asset, orderPriceAndFees, accountId)
-
+        if (!orderTx) {
+          toast.error('Failed to buy datatoken from pool!')
+          setIsLoading(false)
+          return
+        }
         setIsOwned(true)
         setValidOrderTx(orderTx.transactionHash)
       } catch (ex) {


### PR DESCRIPTION
Fixes [catch user approval rejection on buy datatokens #1175](https://github.com/oceanprotocol/market/issues/1175).

Changes proposed in this PR:

- fix approval rejection on buyDtFromPool
- fix approval rejection on order