### PR TITLE
fix txCount on 'Create tokens & pricing' in publish

### DIFF
--- a/src/components/Publish/Steps.tsx
+++ b/src/components/Publish/Steps.tsx
@@ -1,6 +1,6 @@
 import { ReactElement, useEffect } from 'react'
 import { useFormikContext } from 'formik'
-import { wizardSteps } from './_constants'
+import { wizardSteps, initialPublishFeedback } from './_constants'
 import { useWeb3 } from '@context/Web3'
 import { FormPublishData, PublishFeedback } from './_types'
 
@@ -38,7 +38,7 @@ export function Steps({
                 'a single transaction',
                 'a single transaction, after an initial approve transaction'
               )
-            : feedback['1'].description
+            : initialPublishFeedback['1'].description
       }
     })
   }, [values.pricing.type, setFieldValue])

--- a/src/components/Publish/index.tsx
+++ b/src/components/Publish/index.tsx
@@ -63,7 +63,8 @@ export default function PublishPage({
         ...prevState,
         '1': {
           ...prevState['1'],
-          status: 'active'
+          status: 'active',
+          txCount: values.pricing.type === 'dynamic' ? 2 : 1
         }
       }))
 

--- a/src/components/Publish/index.tsx
+++ b/src/components/Publish/index.tsx
@@ -64,7 +64,14 @@ export default function PublishPage({
         '1': {
           ...prevState['1'],
           status: 'active',
-          txCount: values.pricing.type === 'dynamic' ? 2 : 1
+          txCount: values.pricing.type === 'dynamic' ? 2 : 1,
+          description:
+            values.pricing.type === 'dynamic'
+              ? prevState['1'].description.replace(
+                  'a single transaction',
+                  'a single transaction, after an initial approve transaction'
+                )
+              : prevState['1'].description
         }
       }))
 
@@ -103,7 +110,14 @@ export default function PublishPage({
         '1': {
           ...prevState['1'],
           status: 'error',
-          errorMessage: error.message
+          errorMessage: error.message,
+          description:
+            values.pricing.type === 'dynamic'
+              ? prevState['1'].description.replace(
+                  'a single transaction',
+                  'a single transaction, after an initial approve transaction'
+                )
+              : prevState['1'].description
         }
       }))
     }


### PR DESCRIPTION
Fixes [Transactions number in publish submit step #1184](https://github.com/oceanprotocol/market/issues/1184).

Changes proposed in this PR:

- fix txCount on 'Create tokens & pricing' in publish