### PR TITLE
added freeAgreement to pricing validation

### DIFF
--- a/src/components/Publish/Navigation/index.tsx
+++ b/src/components/Publish/Navigation/index.tsx
@@ -20,7 +20,8 @@ export default function Navigation(): ReactElement {
     const isSuccessMetadata = errors.metadata === undefined
     const isSuccessServices = errors.services === undefined
     const isSuccessPricing =
-      errors.pricing === undefined && touched.pricing?.price
+      errors.pricing === undefined &&
+      (touched.pricing?.price || touched.pricing?.freeAgreement)
     const isSuccessPreview =
       isSuccessMetadata && isSuccessServices && isSuccessPricing
 


### PR DESCRIPTION
Fixes Price step remains unchecked for free price asset on publish #1183 

Changes proposed in this PR:

- fix validation of freeAgreement on pricing tab / navigation