### PR TITLE
remove percentage fee from price sum, depends smart contract calculation

### DIFF
--- a/src/@utils/accessDetailsAndPricing.ts
+++ b/src/@utils/accessDetailsAndPricing.ts
@@ -298,10 +298,6 @@ export async function getOrderPriceAndFees(
     .add(new Decimal(+orderPriceAndFee?.consumeMarketOrderFee || 0))
     .add(new Decimal(+orderPriceAndFee?.publisherMarketOrderFee || 0))
     .add(new Decimal(+orderPriceAndFee?.providerFee?.providerFeeAmount || 0))
-    .add(new Decimal(+orderPriceAndFee?.publisherMarketPoolSwapFee || 0))
-    .add(new Decimal(+orderPriceAndFee?.publisherMarketFixedSwapFee || 0))
-    .add(new Decimal(+orderPriceAndFee?.consumeMarketPoolSwapFee || 0))
-    .add(new Decimal(+orderPriceAndFee?.consumeMarketFixedSwapFee || 0))
     .toString()
   return orderPriceAndFee
 }

--- a/src/@utils/fixedRateExchange.ts
+++ b/src/@utils/fixedRateExchange.ts
@@ -2,6 +2,7 @@ import { FixedRateExchange, PriceAndFees } from '@oceanprotocol/lib'
 import { AccessDetails } from 'src/@types/Price'
 import Web3 from 'web3'
 import { getOceanConfig } from './ocean'
+import { getSiteMetadata } from './siteConfig'
 import { getDummyWeb3 } from './web3'
 
 /**
@@ -24,11 +25,13 @@ export async function getFixedBuyPrice(
   }
 
   const config = getOceanConfig(chainId)
+  const { appConfig } = getSiteMetadata()
 
   const fixed = new FixedRateExchange(web3, config.fixedRateExchangeAddress)
   const estimatedPrice = await fixed.calcBaseInGivenOutDT(
     accessDetails.addressOrId,
-    '1'
+    '1',
+    appConfig.consumeMarketPoolSwapFee
   )
   return estimatedPrice
 }


### PR DESCRIPTION
Fixes # .

Changes proposed in this PR:

- reverted percentage based fee from orderPriceAndFee sum
- adopt the same estimatedPrice mechanism as pool, pass consumeMarketSwapFee and depends on calcBaseInGivenOutDT smart contract method calculate the price (consumeMarketSwapFee + publishMarketSwapFee + oceanFee + basePrice)