### PR TITLE
Move auto-changing providerUrl

### DIFF
--- a/src/components/@shared/FormFields/Provider/index.tsx
+++ b/src/components/@shared/FormFields/Provider/index.tsx
@@ -44,7 +44,7 @@ export default function CustomProvider(props: InputProps): ReactElement {
   }
 
   function handleFileInfoClose() {
-    helpers.setValue({ url: '', valid: false })
+    helpers.setValue({ url: '', valid: false, custom: true })
     helpers.setTouched(false)
   }
 
@@ -55,8 +55,7 @@ export default function CustomProvider(props: InputProps): ReactElement {
     const providerUrl =
       oceanConfig?.providerUri || initialValues.services[0].providerUrl.url
 
-    console.log(providerUrl)
-    helpers.setValue({ url: providerUrl, valid: true })
+    helpers.setValue({ url: providerUrl, valid: true, custom: false })
   }
 
   return field?.value?.valid === true ? (

--- a/src/components/@shared/FormFields/Provider/index.tsx
+++ b/src/components/@shared/FormFields/Provider/index.tsx
@@ -8,8 +8,11 @@ import Button from '@shared/atoms/Button'
 import { initialValues } from 'src/components/Publish/_constants'
 import { LoggerInstance, ProviderInstance } from '@oceanprotocol/lib'
 import { FormPublishData } from 'src/components/Publish/_types'
+import { getOceanConfig } from '@utils/ocean'
+import { useWeb3 } from '@context/Web3'
 
 export default function CustomProvider(props: InputProps): ReactElement {
+  const { chainId } = useWeb3()
   const [field, meta, helpers] = useField(props.name)
   const [isLoading, setIsLoading] = useState(false)
   const { setFieldError } = useFormikContext<FormPublishData>()
@@ -47,7 +50,13 @@ export default function CustomProvider(props: InputProps): ReactElement {
 
   function handleDefault(e: React.SyntheticEvent) {
     e.preventDefault()
-    helpers.setValue(initialValues.services[0].providerUrl)
+
+    const oceanConfig = getOceanConfig(chainId)
+    const providerUrl =
+      oceanConfig?.providerUri || initialValues.services[0].providerUrl.url
+
+    console.log(providerUrl)
+    helpers.setValue({ url: providerUrl, valid: true })
   }
 
   return field?.value?.valid === true ? (

--- a/src/components/@shared/FormFields/Provider/index.tsx
+++ b/src/components/@shared/FormFields/Provider/index.tsx
@@ -5,7 +5,6 @@ import { InputProps } from '@shared/FormInput'
 import FileInfo from '../FilesInput/Info'
 import styles from './index.module.css'
 import Button from '@shared/atoms/Button'
-import { initialValues } from 'src/components/Publish/_constants'
 import { LoggerInstance, ProviderInstance } from '@oceanprotocol/lib'
 import { FormPublishData } from 'src/components/Publish/_types'
 import { getOceanConfig } from '@utils/ocean'
@@ -15,8 +14,8 @@ import { useCancelToken } from '@hooks/useCancelToken'
 
 export default function CustomProvider(props: InputProps): ReactElement {
   const { chainId } = useWeb3()
-  const { setFieldError } = useFormikContext<FormPublishData>()
   const newCancelToken = useCancelToken()
+  const { initialValues, setFieldError } = useFormikContext<FormPublishData>()
   const [field, meta, helpers] = useField(props.name)
   const [isLoading, setIsLoading] = useState(false)
 

--- a/src/components/@shared/FormFields/Provider/index.tsx
+++ b/src/components/@shared/FormFields/Provider/index.tsx
@@ -41,8 +41,9 @@ export default function CustomProvider(props: InputProps): ReactElement {
         cancelToken: newCancelToken()
       })
       const providerChainId = providerResponse?.data?.chainId
+      const userChainId = chainId || 1
 
-      if (providerChainId !== chainId)
+      if (providerChainId !== userChainId)
         throw Error(
           '✗ This provider is incompatible with the network your wallet is connected to.'
         )

--- a/src/components/@shared/FormFields/Provider/index.tsx
+++ b/src/components/@shared/FormFields/Provider/index.tsx
@@ -34,7 +34,7 @@ export default function CustomProvider(props: InputProps): ReactElement {
         )
 
       // if all good, add provider to formik state
-      helpers.setValue({ url: field.value.url, valid: isValid })
+      helpers.setValue({ url: field.value.url, valid: isValid, custom: true })
     } catch (error) {
       setFieldError(`${field.name}.url`, error.message)
       LoggerInstance.error(error.message)

--- a/src/components/Publish/Services/index.tsx
+++ b/src/components/Publish/Services/index.tsx
@@ -6,7 +6,6 @@ import IconCompute from '@images/compute.svg'
 import content from '../../../../content/publish/form.json'
 import { getFieldContent } from '../_utils'
 import { FormPublishData } from '../_types'
-import { getOceanConfig } from '@utils/ocean'
 
 const accessTypeOptionsTitles = getFieldContent(
   'access',
@@ -15,8 +14,7 @@ const accessTypeOptionsTitles = getFieldContent(
 
 export default function ServicesFields(): ReactElement {
   // connect with Form state, use for conditional field rendering
-  const { values, setFieldValue, touched, setTouched } =
-    useFormikContext<FormPublishData>()
+  const { values, setFieldValue } = useFormikContext<FormPublishData>()
 
   // name and title should be download, but option value should be access, probably the best way would be to change the component so that option is an object like {name,value}
   const accessTypeOptions = [
@@ -54,15 +52,6 @@ export default function ServicesFields(): ReactElement {
       values.services[0].algorithmPrivacy === true ? 'compute' : 'access'
     )
   }, [values.services[0].algorithmPrivacy, setFieldValue])
-
-  // Auto-change default providerUrl on user network change
-  useEffect(() => {
-    if (!values?.user?.chainId) return
-
-    const config = getOceanConfig(values.user.chainId)
-    config && setFieldValue('services[0].providerUrl.url', config.providerUri)
-    setTouched({ ...touched, services: [{ providerUrl: { url: true } }] })
-  }, [values.user.chainId, setFieldValue, setTouched])
 
   return (
     <>

--- a/src/components/Publish/Steps.tsx
+++ b/src/components/Publish/Steps.tsx
@@ -47,18 +47,28 @@ export function Steps({
 
   // Auto-change default providerUrl on user network change
   useEffect(() => {
-    if (!values?.user?.chainId) return
+    if (
+      !values?.user?.chainId ||
+      values?.services[0]?.providerUrl.custom === true
+    )
+      return
 
     const config = getOceanConfig(values.user.chainId)
     if (config) {
       setFieldValue('services[0].providerUrl', {
         url: config.providerUri,
-        valid: true
+        valid: true,
+        custom: false
       })
     }
 
     setTouched({ ...touched, services: [{ providerUrl: { url: true } }] })
-  }, [values.user.chainId, setFieldValue, setTouched])
+  }, [
+    values?.user?.chainId,
+    values?.services[0]?.providerUrl.custom,
+    setFieldValue,
+    setTouched
+  ])
 
   const { component } = wizardSteps.filter(
     (stepContent) => stepContent.step === values.user.stepCurrent

--- a/src/components/Publish/Steps.tsx
+++ b/src/components/Publish/Steps.tsx
@@ -50,7 +50,13 @@ export function Steps({
     if (!values?.user?.chainId) return
 
     const config = getOceanConfig(values.user.chainId)
-    config && setFieldValue('services[0].providerUrl.url', config.providerUri)
+    if (config) {
+      setFieldValue('services[0].providerUrl', {
+        url: config.providerUri,
+        valid: true
+      })
+    }
+
     setTouched({ ...touched, services: [{ providerUrl: { url: true } }] })
   }, [values.user.chainId, setFieldValue, setTouched])
 

--- a/src/components/Publish/_constants.tsx
+++ b/src/components/Publish/_constants.tsx
@@ -74,7 +74,8 @@ export const initialValues: FormPublishData = {
       access: 'access',
       providerUrl: {
         url: 'https://provider.mainnet.oceanprotocol.com',
-        valid: true
+        valid: true,
+        custom: false
       },
       computeOptions
     }

--- a/src/components/Publish/_types.ts
+++ b/src/components/Publish/_types.ts
@@ -16,7 +16,7 @@ export interface FormPublishService {
   timeout: string
   dataTokenOptions: { name: string; symbol: string }
   access: 'Download' | 'Compute' | string
-  providerUrl?: { url: string; valid: boolean }
+  providerUrl: { url: string; valid: boolean; custom: boolean }
   algorithmPrivacy?: boolean
   computeOptions?: ServiceComputeOptions
 }

--- a/src/components/Publish/_validation.ts
+++ b/src/components/Publish/_validation.ts
@@ -52,7 +52,8 @@ const validationService = {
     .required('Required'),
   providerUrl: Yup.object().shape({
     url: Yup.string().url('Must be a valid URL.').required('Required'),
-    valid: Yup.boolean().isTrue().required('Valid Provider is required.')
+    valid: Yup.boolean().isTrue().required('Valid Provider is required.'),
+    custom: Yup.boolean()
   })
 }
 

--- a/src/components/Publish/index.tsx
+++ b/src/components/Publish/index.tsx
@@ -215,55 +215,6 @@ export default function PublishPage({
         }
       }))
     }
-
-    // --------------------------------------------------
-    // 3. Integrity check of DDO before & after publishing
-    // --------------------------------------------------
-
-    // TODO: not sure we want to do this at this step, seems overkill
-
-    // if we want to do this we just need to fetch it from aquarius. If we want to fetch from chain and decrypt, we would have more metamask pop-ups (not UX friendly)
-    // decrypt also validates the checksum
-
-    // TODO: remove the commented lines of code until `setSuccess`, didn't remove them yet because maybe i missed something
-
-    // --------------------------------------------------
-    // 1. Mint NFT & datatokens & put in pool
-    // --------------------------------------------------
-    // const nftOptions = values.metadata.nft
-    // const nftCreateData = generateNftCreateData(nftOptions)
-
-    //  figure out syntax of ercParams we most likely need to pass
-    // to createNftWithErc() as we need to pass options for the datatoken.
-    // const ercParams = {}
-    // const priceOptions = {
-    //   // swapFee is tricky: to get 0.1% you need to send 0.001 as value
-    //   swapFee: `${values.pricing.swapFee / 100}`
-    // }
-    // const txMint = await createNftWithErc(accountId, nftCreateData)
-
-    // figure out how to get nftAddress & datatokenAddress from tx log.
-    // const { nftAddress, datatokenAddress } = txMint.logs[0].args
-    // if (!nftAddress || !datatokenAddress) { throw new Error() }
-    //
-    // --------------------------------------------------
-    // 2. Construct and publish DDO
-    // --------------------------------------------------
-    // const did = sha256(`${nftAddress}${chainId}`)
-    // const ddo = transformPublishFormToDdo(values, datatokenAddress, nftAddress)
-    // const txPublish = await publish(ddo)
-    //
-    // --------------------------------------------------
-    // 3. Integrity check of DDO before & after publishing
-    // --------------------------------------------------
-    // const checksumBefore = sha256(ddo)
-    // const ddoFromChain = await getDdoFromChain(ddo.id)
-    // const ddoFromChainDecrypted = await decryptDdo(ddoFromChain)
-    // const checksumAfter = sha256(ddoFromChainDecrypted)
-
-    // if (checksumBefore !== checksumAfter) {
-    //   throw new Error('DDO integrity check failed!')
-    // }
   }
 
   return isInPurgatory && purgatoryData ? null : (

--- a/src/components/Publish/index.tsx
+++ b/src/components/Publish/index.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useState, useRef, useEffect } from 'react'
+import React, { ReactElement, useState, useRef } from 'react'
 import { Form, Formik } from 'formik'
 import { initialPublishFeedback, initialValues } from './_constants'
 import { useAccountPurgatory } from '@hooks/useAccountPurgatory'
@@ -14,20 +14,14 @@ import { Steps } from './Steps'
 import { FormPublishData, PublishFeedback } from './_types'
 import { useUserPreferences } from '@context/UserPreferences'
 import useNftFactory from '@hooks/contracts/useNftFactory'
-import {
-  Nft,
-  getHash,
-  ProviderInstance,
-  LoggerInstance,
-  DDO
-} from '@oceanprotocol/lib'
+import { ProviderInstance, LoggerInstance, DDO } from '@oceanprotocol/lib'
 import { getOceanConfig } from '@utils/ocean'
 import { validationSchema } from './_validation'
 import { useAbortController } from '@hooks/useAbortController'
 import { setNFTMetadataAndTokenURI } from '@utils/nft'
 
 // TODO: restore FormikPersist, add back clear form action
-const formName = 'ocean-publish-form'
+// const formName = 'ocean-publish-form'
 
 export default function PublishPage({
   content
@@ -276,7 +270,7 @@ export default function PublishPage({
     <Formik
       initialValues={initialValues}
       validationSchema={validationSchema}
-      onSubmit={async (values, { resetForm }) => {
+      onSubmit={async (values) => {
         // kick off publishing
         await handleSubmit(values)
       }}


### PR DESCRIPTION
- fixes #1254

Was only active when _Access_ screen was rendered, so moved into `Steps.tsx` which holds all our auto effects across all publish screens.

Additional tweaks:

- when user dismisses existing default provider, then changes network: nothing will happen so no custom provider URL is being overwritten
- when clicking Default Provider action, now grabbing the default provider URL from ocean config based on user wallet network, and if no wallet is connected grabbing this from initialValues as before
- additionally check if fetched provider is compatible with user's wallet network