### PR TITLE
Warn about publishing html files, unified file error states

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26728,6 +26728,7 @@
         "cross-fetch": "^3.1.5",
         "crypto-js": "^4.1.1",
         "decimal.js": "^10.3.1",
+        "web3": "^1.7.1",
         "web3-core": "^1.7.1",
         "web3-eth-contract": "^1.7.1"
       }
@@ -26830,6 +26831,7 @@
       "integrity": "sha512-5vwpq6kbvwkQwKqAoOU3L72GZ3Ta8RRrewKj9OJRolx28KLJJ8Dg9Rf7obRwt5jQA9bkYd8gqzMTrI7H3xLfaw==",
       "dev": true,
       "requires": {
+        "@oclif/config": "^1.15.1",
         "@oclif/errors": "^1.3.3",
         "@oclif/parser": "^3.8.3",
         "@oclif/plugin-help": "^3",

--- a/src/components/@shared/FormFields/FilesInput/Info.module.css
+++ b/src/components/@shared/FormFields/FilesInput/Info.module.css
@@ -50,3 +50,8 @@
 .info li.error {
   color: var(--brand-alert-red);
 }
+
+.warning {
+  margin-top: calc(var(--spacer) / 3);
+  margin-left: 0;
+}

--- a/src/components/@shared/FormFields/FilesInput/Info.module.css
+++ b/src/components/@shared/FormFields/FilesInput/Info.module.css
@@ -6,8 +6,19 @@
   position: relative;
 }
 
-.hasError {
-  border-color: var(--brand-alert-red);
+.info ul {
+  margin: 0;
+}
+
+.info li {
+  display: inline-block;
+  font-size: var(--font-size-small);
+  margin-right: calc(var(--spacer) / 2);
+  color: var(--color-secondary);
+}
+
+.info li.success {
+  color: var(--brand-alert-green);
 }
 
 .url {
@@ -20,15 +31,9 @@
   padding-right: calc(var(--spacer) / 2);
 }
 
-.info ul {
-  margin: 0;
-}
-
-.info li {
-  display: inline-block;
-  font-size: var(--font-size-small);
-  margin-right: calc(var(--spacer) / 2);
-  color: var(--color-secondary);
+.warning {
+  margin-top: calc(var(--spacer) / 3);
+  margin-left: 0;
 }
 
 .removeButton {
@@ -41,17 +46,4 @@
   cursor: pointer;
   color: var(--font-color-text);
   background-color: transparent;
-}
-
-.info li.success {
-  color: var(--brand-alert-green);
-}
-
-.info li.error {
-  color: var(--brand-alert-red);
-}
-
-.warning {
-  margin-top: calc(var(--spacer) / 3);
-  margin-left: 0;
 }

--- a/src/components/@shared/FormFields/FilesInput/Info.module.css
+++ b/src/components/@shared/FormFields/FilesInput/Info.module.css
@@ -8,7 +8,6 @@
 
 .hasError {
   border-color: var(--brand-alert-red);
-  background-color: var(--brand-white);
 }
 
 .url {

--- a/src/components/@shared/FormFields/FilesInput/Info.tsx
+++ b/src/components/@shared/FormFields/FilesInput/Info.tsx
@@ -25,13 +25,7 @@ export default function FileInfo({
     <div className={`${styles.info} ${file.valid ? '' : styles.hasError}`}>
       <h3 className={styles.url}>{file.url}</h3>
       <ul>
-        {file.valid ? (
-          <li className={styles.success}>✓ URL confirmed</li>
-        ) : (
-          <li className={styles.error}>
-            ✗ No valid file detected. Check your URL and try again.
-          </li>
-        )}
+        <li className={styles.success}>✓ URL confirmed</li>
         {file.contentLength && <li>{prettySize(+file.contentLength)}</li>}
         {contentTypeCleaned && <li>{contentTypeCleaned}</li>}
       </ul>

--- a/src/components/@shared/FormFields/FilesInput/Info.tsx
+++ b/src/components/@shared/FormFields/FilesInput/Info.tsx
@@ -11,26 +11,19 @@ export default function FileInfo({
   file: FileMetadata
   handleClose(): void
 }): ReactElement {
-  return file.valid ? (
-    <div className={styles.info}>
+  return (
+    <div className={`${styles.info} ${file.valid ? '' : styles.hasError}`}>
       <h3 className={styles.url}>{file.url}</h3>
       <ul>
-        <li className={styles.success}>✓ URL confirmed</li>
-        {file.contentLength && <li>{prettySize(+file.contentLength)}</li>}
-        {file.contentType && <li>{cleanupContentType(file.contentType)}</li>}
-      </ul>
-      <button className={styles.removeButton} onClick={handleClose}>
-        &times;
-      </button>
-    </div>
-  ) : (
-    <div className={`${styles.info} ${!file.valid ? styles.hasError : ''}`}>
-      <h3 className={styles.url}>{file.url}</h3>
-      <ul>
-        <li className={styles.error}>
-          {' '}
-          ✗ No valid file detected. Check your URL and try again.
-        </li>
+        {file.valid ? (
+          <li className={styles.success}>✓ URL confirmed</li>
+        ) : (
+          <li className={styles.error}>
+            {' '}
+            ✗ No valid file detected. Check your URL and try again.
+          </li>
+        )}
+
         {file.contentLength && <li>{prettySize(+file.contentLength)}</li>}
         {file.contentType && <li>{cleanupContentType(file.contentType)}</li>}
       </ul>

--- a/src/components/@shared/FormFields/FilesInput/Info.tsx
+++ b/src/components/@shared/FormFields/FilesInput/Info.tsx
@@ -22,7 +22,7 @@ export default function FileInfo({
   const shouldWarnAboutFile = file.valid && contentTypeCleaned === 'html'
 
   return (
-    <div className={`${styles.info} ${file.valid ? '' : styles.hasError}`}>
+    <div className={styles.info}>
       <h3 className={styles.url}>{file.url}</h3>
       <ul>
         <li className={styles.success}>✓ URL confirmed</li>

--- a/src/components/@shared/FormFields/FilesInput/Info.tsx
+++ b/src/components/@shared/FormFields/FilesInput/Info.tsx
@@ -32,7 +32,7 @@ export default function FileInfo({
       {shouldWarnAboutFile && (
         <Alert
           state="info"
-          text={`Your file was detected as ${contentTypeCleaned}, which is unusal for a data asset. Are you sure?`}
+          text={`Your file was detected as ${contentTypeCleaned}, which is unusal for a data asset. If you did not intend to use a ${contentTypeCleaned} file, try a different URL pointing directly to your data asset file.`}
           className={styles.warning}
         />
       )}

--- a/src/components/@shared/FormFields/FilesInput/Info.tsx
+++ b/src/components/@shared/FormFields/FilesInput/Info.tsx
@@ -3,6 +3,7 @@ import { prettySize } from './utils'
 import cleanupContentType from '@utils/cleanupContentType'
 import styles from './Info.module.css'
 import { FileMetadata } from '@oceanprotocol/lib'
+import Alert from '@shared/atoms/Alert'
 
 export default function FileInfo({
   file,
@@ -11,6 +12,15 @@ export default function FileInfo({
   file: FileMetadata
   handleClose(): void
 }): ReactElement {
+  const contentTypeCleaned = file.contentType
+    ? cleanupContentType(file.contentType)
+    : null
+
+  // Prevent accidential publishing of error pages (e.g. 404) for
+  // popular file hosting services by warning about it.
+  // See https://github.com/oceanprotocol/market/issues/1246
+  const shouldWarnAboutFile = file.valid && contentTypeCleaned === 'html'
+
   return (
     <div className={`${styles.info} ${file.valid ? '' : styles.hasError}`}>
       <h3 className={styles.url}>{file.url}</h3>
@@ -19,14 +29,19 @@ export default function FileInfo({
           <li className={styles.success}>✓ URL confirmed</li>
         ) : (
           <li className={styles.error}>
-            {' '}
             ✗ No valid file detected. Check your URL and try again.
           </li>
         )}
-
         {file.contentLength && <li>{prettySize(+file.contentLength)}</li>}
-        {file.contentType && <li>{cleanupContentType(file.contentType)}</li>}
+        {contentTypeCleaned && <li>{contentTypeCleaned}</li>}
       </ul>
+      {shouldWarnAboutFile && (
+        <Alert
+          state="info"
+          text={`Your file was detected as ${contentTypeCleaned}, which is unusal for a data asset. Are you sure?`}
+          className={styles.warning}
+        />
+      )}
       <button className={styles.removeButton} onClick={handleClose}>
         &times;
       </button>

--- a/src/components/@shared/FormFields/FilesInput/index.tsx
+++ b/src/components/@shared/FormFields/FilesInput/index.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useCallback, useEffect, useState } from 'react'
+import React, { ReactElement, useState } from 'react'
 import { useField, useFormikContext } from 'formik'
 import { toast } from 'react-toastify'
 import FileInfo from './Info'
@@ -7,6 +7,7 @@ import { InputProps } from '@shared/FormInput'
 import { initialValues } from 'src/components/Publish/_constants'
 import { getFileUrlInfo } from '@utils/provider'
 import { FormPublishData } from 'src/components/Publish/_types'
+import { LoggerInstance } from '@oceanprotocol/lib'
 
 export default function FilesInput(props: InputProps): ReactElement {
   const [field, meta, helpers] = useField(props.name)
@@ -14,48 +15,22 @@ export default function FilesInput(props: InputProps): ReactElement {
   const [isLoading, setIsLoading] = useState(false)
   const { values } = useFormikContext<FormPublishData>()
 
-  const loadFileInfo = useCallback(
-    (url: string) => {
-      const providerUri =
-        (values.services && values.services[0].providerUrl.url) ||
-        'https://provider.mainnet.oceanprotocol.com'
-
-      async function validateUrl() {
-        try {
-          setIsLoading(true)
-          const checkedFile = await getFileUrlInfo(url, providerUri)
-          setIsInvalidUrl(!checkedFile[0].valid)
-          checkedFile && helpers.setValue([{ url, ...checkedFile[0] }])
-        } catch (error) {
-          toast.error(
-            'Could not fetch file info. Please check URL and try again'
-          )
-          console.error(error.message)
-        } finally {
-          setIsLoading(false)
-        }
-      }
-
-      validateUrl()
-    },
-    [helpers, values.services]
-  )
-
-  useEffect(() => {
-    // try load from initial values, kinda hacky but it works
-    if (
-      props.value &&
-      props.value.length > 0 &&
-      typeof props.value[0] === 'string'
-    ) {
-      loadFileInfo(props.value[0].toString())
-    }
-  }, [loadFileInfo, props])
-
-  async function handleButtonClick(e: React.SyntheticEvent, url: string) {
+  async function handleValidation(e: React.SyntheticEvent, url: string) {
     // File example 'https://oceanprotocol.com/tech-whitepaper.pdf'
     e.preventDefault()
-    loadFileInfo(url)
+
+    try {
+      const providerUrl = values?.services[0].providerUrl.url
+      setIsLoading(true)
+      const checkedFile = await getFileUrlInfo(url, providerUrl)
+      setIsInvalidUrl(!checkedFile[0].valid)
+      checkedFile && helpers.setValue([{ url, ...checkedFile[0] }])
+    } catch (error) {
+      toast.error('Could not fetch file info. Please check URL and try again')
+      LoggerInstance.error(error.message)
+    } finally {
+      setIsLoading(false)
+    }
   }
 
   function handleClose() {
@@ -74,7 +49,7 @@ export default function FilesInput(props: InputProps): ReactElement {
           name={`${field.name}[0].url`}
           hasError={Boolean(meta.touched && isInvalidUrl)}
           isLoading={isLoading}
-          handleButtonClick={handleButtonClick}
+          handleButtonClick={handleValidation}
         />
       )}
     </>

--- a/src/components/@shared/FormFields/FilesInput/index.tsx
+++ b/src/components/@shared/FormFields/FilesInput/index.tsx
@@ -24,7 +24,7 @@ export default function FilesInput(props: InputProps): ReactElement {
 
       // error if something's not right from response
       if (!checkedFile)
-        throw Error('Could not fetch file info. Please check URL and try again')
+        throw Error('Could not fetch file info. Is your network down?')
 
       if (checkedFile[0].valid === false)
         throw Error('✗ No valid file detected. Check your URL and try again.')

--- a/src/components/@shared/FormFields/FilesInput/index.tsx
+++ b/src/components/@shared/FormFields/FilesInput/index.tsx
@@ -1,6 +1,5 @@
 import React, { ReactElement, useState } from 'react'
 import { useField, useFormikContext } from 'formik'
-import { toast } from 'react-toastify'
 import FileInfo from './Info'
 import UrlInput from '../URLInput'
 import { InputProps } from '@shared/FormInput'
@@ -26,7 +25,9 @@ export default function FilesInput(props: InputProps): ReactElement {
       setIsInvalidUrl(!checkedFile[0].valid)
       checkedFile && helpers.setValue([{ url, ...checkedFile[0] }])
     } catch (error) {
-      toast.error('Could not fetch file info. Please check URL and try again')
+      helpers.setError(
+        'Could not fetch file info. Please check URL and try again'
+      )
       LoggerInstance.error(error.message)
     } finally {
       setIsLoading(false)

--- a/src/components/@shared/FormFields/FilesInput/index.tsx
+++ b/src/components/@shared/FormFields/FilesInput/index.tsx
@@ -3,7 +3,6 @@ import { useField, useFormikContext } from 'formik'
 import FileInfo from './Info'
 import UrlInput from '../URLInput'
 import { InputProps } from '@shared/FormInput'
-import { initialValues } from 'src/components/Publish/_constants'
 import { getFileUrlInfo } from '@utils/provider'
 import { FormPublishData } from 'src/components/Publish/_types'
 import { LoggerInstance } from '@oceanprotocol/lib'
@@ -40,13 +39,13 @@ export default function FilesInput(props: InputProps): ReactElement {
   }
 
   function handleClose() {
-    helpers.setValue(initialValues.services[0].files)
+    helpers.setValue(meta.initialValue)
     helpers.setTouched(false)
   }
 
   return (
     <>
-      {field.value[0].valid === true ? (
+      {field?.value?.[0]?.valid === true ? (
         <FileInfo file={field.value[0]} handleClose={handleClose} />
       ) : (
         <UrlInput

--- a/src/components/@shared/FormFields/Provider/index.module.css
+++ b/src/components/@shared/FormFields/Provider/index.module.css
@@ -2,8 +2,14 @@
   composes: error from '@shared/FormInput/index.module.css';
 }
 
-.restore {
+.default {
   font-family: var(--font-family-base);
   text-transform: none;
   font-weight: var(--font-weight-base);
+
+  /* take it out of layout so error messages 
+  are not pushed down */
+  position: absolute;
+  left: 0;
+  bottom: -30%;
 }

--- a/src/components/@shared/FormFields/Provider/index.tsx
+++ b/src/components/@shared/FormFields/Provider/index.tsx
@@ -22,6 +22,11 @@ export default function CustomProvider(props: InputProps): ReactElement {
       const isValid = await ProviderInstance.isValidProvider(field.value.url)
 
       // error if something's not right from response
+      // TODO: Figure out way to detect failed response, and throw that before
+      // this check.
+      // No way to detect a failed response with ProviderInstance.isValidProvider,
+      // making this error show up for multiple cases it shouldn't, namely network
+      // or provider down.
       if (!isValid)
         throw Error(
           '✗ No valid provider detected. Check your URL and try again.'

--- a/src/components/@shared/FormFields/Provider/index.tsx
+++ b/src/components/@shared/FormFields/Provider/index.tsx
@@ -54,7 +54,6 @@ export default function CustomProvider(props: InputProps): ReactElement {
         submitText="Validate"
         {...props}
         name={`${field.name}.url`}
-        hasError={Boolean(meta.touched && meta.error)}
         isLoading={isLoading}
         handleButtonClick={handleValidateButtonClick}
       />

--- a/src/components/@shared/FormFields/Provider/index.tsx
+++ b/src/components/@shared/FormFields/Provider/index.tsx
@@ -45,7 +45,7 @@ export default function CustomProvider(props: InputProps): ReactElement {
     helpers.setTouched(false)
   }
 
-  function handleRestore(e: React.SyntheticEvent) {
+  function handleDefault(e: React.SyntheticEvent) {
     e.preventDefault()
     helpers.setValue(initialValues.services[0].providerUrl)
   }
@@ -64,8 +64,8 @@ export default function CustomProvider(props: InputProps): ReactElement {
       <Button
         style="text"
         size="small"
-        onClick={handleRestore}
-        className={styles.restore}
+        onClick={handleDefault}
+        className={styles.default}
       >
         Use Default Provider
       </Button>

--- a/src/components/@shared/FormFields/Provider/index.tsx
+++ b/src/components/@shared/FormFields/Provider/index.tsx
@@ -22,14 +22,12 @@ export default function CustomProvider(props: InputProps): ReactElement {
       const isValid = await ProviderInstance.isValidProvider(field.value.url)
 
       // error if something's not right from response
-      // TODO: Figure out way to detect failed response, and throw that before
-      // this check.
-      // No way to detect a failed response with ProviderInstance.isValidProvider,
-      // making this error show up for multiple cases it shouldn't, namely network
-      // or provider down.
+      // No way to detect a failed request with ProviderInstance.isValidProvider,
+      // making this error show up for multiple cases it shouldn't, like network
+      // down.
       if (!isValid)
         throw Error(
-          '✗ No valid provider detected. Check your URL and try again.'
+          '✗ No valid provider detected. Check your network, your URL and try again.'
         )
 
       // if all good, add provider to formik state

--- a/src/components/@shared/FormFields/URLInput/index.module.css
+++ b/src/components/@shared/FormFields/URLInput/index.module.css
@@ -10,8 +10,3 @@
 .error {
   composes: error from '@shared/FormInput/index.module.css';
 }
-
-.success {
-  background: var(--brand-alert-green);
-  opacity: 1 !important;
-}

--- a/src/components/@shared/FormFields/URLInput/index.tsx
+++ b/src/components/@shared/FormFields/URLInput/index.tsx
@@ -12,14 +12,12 @@ export default function URLInput({
   handleButtonClick,
   isLoading,
   name,
-  hasError,
   ...props
 }: {
   submitText: string
   handleButtonClick(e: React.SyntheticEvent, data: string): void
   isLoading: boolean
   name: string
-  hasError: boolean
 }): ReactElement {
   const [field, meta] = useField(name)
   const [isButtonDisabled, setIsButtonDisabled] = useState(true)


### PR DESCRIPTION
- closes #1246
- if file is valid and content type ends up as `html`, show a warning.
- cleanup for less repetitive markup
- cleanup for less code doing the same thing with less logic in file check 

<img width="914" alt="Screen Shot 2022-03-30 at 14 34 19" src="https://user-images.githubusercontent.com/90316/160847126-b9d09142-5aa6-4d06-8697-2d4138efa494.png">
 
- cleaned up and visually unified error states, resulting in file only being "added" when `valid: true`
  - while each error state (toast, input error, file added but show as error) was kinda nice, using 3 different error UI for 3 different errors on the same thing seemed a bit overkill
  - so left the only intended UI for all errors in the publish form:
  - provider not reachable/no network etc. (was shown in toast before with no error state on input at all):
  <img width="955" alt="Screen Shot 2022-03-29 at 22 37 54" src="https://user-images.githubusercontent.com/90316/160714750-16689a29-ac19-4525-8341-d060f46f006e.png">
  
  - file response is `valid: false` (was a new error state before, added in #1221):
  <img width="897" alt="Screen Shot 2022-03-29 at 23 00 21" src="https://user-images.githubusercontent.com/90316/160714760-97d2459a-21c4-4c2f-bbd2-7fb78b88cfb3.png">
 