### PR TITLE
c2d show price with fee, exclude provider fee

### DIFF
--- a/src/components/Asset/AssetActions/Compute/FormComputeDataset.tsx
+++ b/src/components/Asset/AssetActions/Compute/FormComputeDataset.tsx
@@ -10,7 +10,7 @@ import { useAsset } from '@context/Asset'
 import { useWeb3 } from '@context/Web3'
 import content from '../../../../../content/pages/startComputeDataset.json'
 import { Asset } from '@oceanprotocol/lib'
-import { AccessDetails } from 'src/@types/Price'
+import { AccessDetails, OrderPriceAndFees } from 'src/@types/Price'
 import {
   getAccessDetailsForAssets,
   getAccessDetails
@@ -40,7 +40,9 @@ export default function FormStartCompute({
   selectedComputeAssetTimeout,
   stepText,
   isConsumable,
-  consumableFeedback
+  consumableFeedback,
+  datasetOrderPriceAndFees,
+  algoOrderPriceAndFees
 }: {
   algorithms: AssetSelectionAsset[]
   ddoListAlgorithms: Asset[]
@@ -65,6 +67,8 @@ export default function FormStartCompute({
   stepText: string
   isConsumable: boolean
   consumableFeedback: string
+  datasetOrderPriceAndFees?: OrderPriceAndFees
+  algoOrderPriceAndFees?: OrderPriceAndFees
 }): ReactElement {
   const { isValid, values }: FormikContextType<{ algorithm: string }> =
     useFormikContext()
@@ -107,11 +111,16 @@ export default function FormStartCompute({
     if (!asset?.accessDetails || !selectedAlgorithmAsset?.accessDetails) return
 
     const priceDataset =
-      hasPreviousOrder || hasDatatoken ? 0 : Number(asset.accessDetails.price)
+      hasPreviousOrder || hasDatatoken
+        ? 0
+        : Number(datasetOrderPriceAndFees?.price || asset.accessDetails.price)
     const priceAlgo =
       hasPreviousOrderSelectedComputeAsset || hasDatatokenSelectedComputeAsset
         ? 0
-        : Number(selectedAlgorithmAsset?.accessDetails.price)
+        : Number(
+            algoOrderPriceAndFees?.price ||
+              selectedAlgorithmAsset?.accessDetails.price
+          )
 
     setTotalPrice((priceDataset + priceAlgo).toString())
   }, [
@@ -120,7 +129,9 @@ export default function FormStartCompute({
     hasPreviousOrder,
     hasDatatoken,
     hasPreviousOrderSelectedComputeAsset,
-    hasDatatokenSelectedComputeAsset
+    hasDatatokenSelectedComputeAsset,
+    datasetOrderPriceAndFees,
+    algoOrderPriceAndFees
   ])
 
   useEffect(() => {

--- a/src/components/Asset/AssetActions/Compute/FormComputeDataset.tsx
+++ b/src/components/Asset/AssetActions/Compute/FormComputeDataset.tsx
@@ -74,6 +74,12 @@ export default function FormStartCompute({
     useFormikContext()
   const { asset, isAssetNetwork } = useAsset()
   const [totalPrice, setTotalPrice] = useState(asset?.accessDetails?.price)
+  const [datasetOrderPrice, setDatasetOrderPrice] = useState(
+    asset?.accessDetails?.price
+  )
+  const [algoOrderPrice, setAlgoOrderPrice] = useState(
+    selectedAlgorithmAsset?.accessDetails?.price
+  )
   const [isBalanceSufficient, setIsBalanceSufficient] = useState<boolean>(false)
   const { accountId, balance } = useWeb3()
 
@@ -110,6 +116,13 @@ export default function FormStartCompute({
   useEffect(() => {
     if (!asset?.accessDetails || !selectedAlgorithmAsset?.accessDetails) return
 
+    setDatasetOrderPrice(
+      datasetOrderPriceAndFees?.price || asset.accessDetails.price
+    )
+    setAlgoOrderPrice(
+      algoOrderPriceAndFees?.price ||
+        selectedAlgorithmAsset?.accessDetails.price
+    )
     const priceDataset =
       hasPreviousOrder || hasDatatoken
         ? 0
@@ -164,6 +177,8 @@ export default function FormStartCompute({
         algorithmConsumeDetails={selectedAlgorithmAsset?.accessDetails}
         symbol={oceanSymbol}
         totalPrice={Number.parseFloat(totalPrice)}
+        datasetOrderPrice={datasetOrderPrice}
+        algoOrderPrice={algoOrderPrice}
       />
 
       <ButtonBuy

--- a/src/components/Asset/AssetActions/Compute/PriceOutput.tsx
+++ b/src/components/Asset/AssetActions/Compute/PriceOutput.tsx
@@ -15,6 +15,8 @@ interface PriceOutputProps {
   hasDatatokenSelectedComputeAsset: boolean
   algorithmConsumeDetails: AccessDetails
   selectedComputeAssetTimeout: string
+  datasetOrderPrice?: number
+  algoOrderPrice?: number
 }
 
 function Row({
@@ -62,7 +64,9 @@ export default function PriceOutput({
   hasPreviousOrderSelectedComputeAsset,
   hasDatatokenSelectedComputeAsset,
   algorithmConsumeDetails,
-  selectedComputeAssetTimeout
+  selectedComputeAssetTimeout,
+  datasetOrderPrice,
+  algoOrderPrice
 }: PriceOutputProps): ReactElement {
   const { asset } = useAsset()
 
@@ -76,14 +80,20 @@ export default function PriceOutput({
             <Row
               hasPreviousOrder={hasPreviousOrder}
               hasDatatoken={hasDatatoken}
-              price={Number.parseFloat(asset?.accessDetails?.price)}
+              price={
+                datasetOrderPrice ||
+                Number.parseFloat(asset?.accessDetails?.price)
+              }
               timeout={assetTimeout}
               symbol={symbol}
             />
             <Row
               hasPreviousOrder={hasPreviousOrderSelectedComputeAsset}
               hasDatatoken={hasDatatokenSelectedComputeAsset}
-              price={Number.parseFloat(algorithmConsumeDetails?.price)}
+              price={
+                algoOrderPrice ||
+                Number.parseFloat(algorithmConsumeDetails?.price)
+              }
               timeout={selectedComputeAssetTimeout}
               symbol={symbol}
               sign="+"

--- a/src/components/Asset/AssetActions/Compute/index.tsx
+++ b/src/components/Asset/AssetActions/Compute/index.tsx
@@ -85,8 +85,12 @@ export default function Compute({
   const [computeStatusText, setComputeStatusText] = useState('')
   const [datasetOrderPriceAndFees, setDatasetOrderPriceAndFees] =
     useState<OrderPriceAndFees>()
+  const [isRequestingDataseOrderPrice, setIsRequestingDataseOrderPrice] =
+    useState(false)
   const [algoOrderPriceAndFees, setAlgoOrderPriceAndFees] =
     useState<OrderPriceAndFees>()
+  const [isRequestingAlgoOrderPrice, setIsRequestingAlgoOrderPrice] =
+    useState(false)
   const isComputeButtonDisabled =
     isJobStarting === true ||
     file === null ||
@@ -119,8 +123,12 @@ export default function Compute({
         asset?.accessDetails?.type === 'free'
       )
         return
+
+      setIsRequestingDataseOrderPrice(true)
+      setComputeStatusText('Calculating price including fees.')
       const orderPriceAndFees = await getOrderPriceAndFees(asset, accountId)
       setDatasetOrderPriceAndFees(orderPriceAndFees)
+      setIsRequestingDataseOrderPrice(false)
     }
 
     initDatasetPriceAndFees()
@@ -141,11 +149,15 @@ export default function Compute({
         selectedAlgorithmAsset?.accessDetails?.type === 'free'
       )
         return
+
+      setIsRequestingAlgoOrderPrice(true)
+      setComputeStatusText('Calculating price including fees.')
       const orderPriceAndFees = await getOrderPriceAndFees(
         selectedAlgorithmAsset,
         accountId
       )
       setAlgoOrderPriceAndFees(orderPriceAndFees)
+      setIsRequestingAlgoOrderPrice(false)
     }
 
     async function initSelectedAlgo() {
@@ -444,7 +456,11 @@ export default function Compute({
             ddoListAlgorithms={ddoAlgorithmList}
             selectedAlgorithmAsset={selectedAlgorithmAsset}
             setSelectedAlgorithm={setSelectedAlgorithmAsset}
-            isLoading={isJobStarting}
+            isLoading={
+              isJobStarting ||
+              isRequestingDataseOrderPrice ||
+              isRequestingAlgoOrderPrice
+            }
             isComputeButtonDisabled={isComputeButtonDisabled}
             hasPreviousOrder={validOrderTx !== undefined}
             hasDatatoken={hasDatatoken}


### PR DESCRIPTION
Fixes # .

Changes proposed in this PR:

- Show dataset price with fee
- Show total [dataset + algo] price with fee (not sure if should show price with fee for each algorithm in list)
- NOTE that in `FormComputeDataset` does check if has DT and exclude price, however now there is swap and order fee, therefore if has DT should only exclude swap fee, but not order fee, I guess more to be enhance on `accessDetailsAndPricing.getOrderPriceAndFees`, so of course didn't include part of this PR
- NOTE that provider fee also excluded for both dataset and algo