### PR TITLE
Fix error when sample on edit is empty

### DIFF
--- a/src/components/@shared/FormFields/FilesInput/index.tsx
+++ b/src/components/@shared/FormFields/FilesInput/index.tsx
@@ -65,7 +65,7 @@ export default function FilesInput(props: InputProps): ReactElement {
 
   return (
     <>
-      {field.value[0].valid !== undefined ? (
+      {field?.value && field?.value[0]?.valid !== undefined ? (
         <FileInfo file={field.value[0]} handleClose={handleClose} />
       ) : (
         <UrlInput


### PR DESCRIPTION
Fixes #1286  .

Changes proposed in this PR:

- fix app crashing trying to edit an asset with no sample file set
