### PR TITLE
add custom codeclimate config

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -20,7 +20,7 @@ checks:
       threshold: 20
   method-lines:
     config:
-      threshold: 100
+      threshold: 250
   nested-control-flow:
     config:
       threshold: 4

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,3 +1,4 @@
+# https://docs.codeclimate.com/docs/default-analysis-configuration
 # https://docs.codeclimate.com/docs/advanced-configuration
 
 version: '2'
@@ -32,3 +33,19 @@ checks:
   identical-code:
     config:
       threshold: 3
+
+exclude_patterns:
+  - 'config/'
+  - 'db/'
+  - 'dist/'
+  - 'features/'
+  - '**/node_modules/'
+  - 'script/'
+  - '**/spec/'
+  - '**/test/'
+  - '**/tests/'
+  - 'Tests/'
+  - '**/vendor/'
+  - '**/*_test.go'
+  - '**/*.d.ts'
+  - '**/*.stories.tsx'

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,34 @@
+# https://docs.codeclimate.com/docs/advanced-configuration
+
+version: '2'
+checks:
+  argument-count:
+    config:
+      threshold: 4
+  complex-logic:
+    config:
+      threshold: 10
+  file-lines:
+    config:
+      threshold: 500
+  method-complexity:
+    config:
+      threshold: 10
+  method-count:
+    config:
+      threshold: 20
+  method-lines:
+    config:
+      threshold: 100
+  nested-control-flow:
+    config:
+      threshold: 4
+  return-statements:
+    config:
+      threshold: 4
+  similar-code:
+    config:
+      threshold: 3
+  identical-code:
+    config:
+      threshold: 3

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -5,7 +5,7 @@ version: '2'
 checks:
   argument-count:
     config:
-      threshold: 4
+      threshold: 6
   complex-logic:
     config:
       threshold: 10
@@ -29,7 +29,7 @@ checks:
       threshold: 4
   similar-code:
     config:
-      threshold: 3
+      threshold: 4
   identical-code:
     config:
       threshold: 3

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -18,12 +18,13 @@ checks:
   method-lines:
     config:
       threshold: 250
+  # https://docs.codeclimate.com/docs/default-analysis-configuration#per-language-mass-threshold-defaults
   similar-code:
     config:
-      threshold: 4
+      threshold: 55
   identical-code:
     config:
-      threshold: 3
+      threshold: 55
 
 exclude_patterns:
   - 'config/'

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -21,10 +21,10 @@ checks:
   # https://docs.codeclimate.com/docs/default-analysis-configuration#per-language-mass-threshold-defaults
   similar-code:
     config:
-      threshold: 55
+      threshold: 50
   identical-code:
     config:
-      threshold: 55
+      threshold: 50
 
 exclude_patterns:
   - 'config/'

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -15,18 +15,9 @@ checks:
   method-complexity:
     config:
       threshold: 10
-  method-count:
-    config:
-      threshold: 20
   method-lines:
     config:
       threshold: 250
-  nested-control-flow:
-    config:
-      threshold: 4
-  return-statements:
-    config:
-      threshold: 4
   similar-code:
     config:
       threshold: 4
@@ -49,3 +40,4 @@ exclude_patterns:
   - '**/*_test.go'
   - '**/*.d.ts'
   - '**/*.stories.tsx'
+  - '**/*.test.tsx'


### PR DESCRIPTION
Making Codeclimate useful again.

Changes from former defaults:

- `argument-count`: `4` → `6`
- `complex-logic`: `4` → `10`
- `file-lines`: `250` → `500`
- `method-complexity`: `5` → `10`
- `method-lines`: `25` → `100`
- `similiar-code`: `45` → `50`
- `identical-code`: `45` → `50`

for the last 2 items, see https://docs.codeclimate.com/docs/default-analysis-configuration#per-language-mass-threshold-defaults