### PR TITLE
fix transferable NFTs

### DIFF
--- a/src/@utils/nft.ts
+++ b/src/@utils/nft.ts
@@ -5,7 +5,8 @@ import {
   Nft,
   ProviderInstance,
   DDO,
-  MetadataAndTokenURI
+  MetadataAndTokenURI,
+  NftCreateData
 } from '@oceanprotocol/lib'
 import { SvgWaves } from './SvgWaves'
 import Web3 from 'web3'
@@ -64,13 +65,15 @@ const tokenUriPrefix = 'data:application/json;base64,'
 
 export function generateNftCreateData(
   nftMetadata: NftMetadata,
-  accountId: string
+  accountId: string,
+  transferable = true
 ): any {
-  const nftCreateData = {
+  const nftCreateData: NftCreateData = {
     name: nftMetadata.name,
     symbol: nftMetadata.symbol,
     templateIndex: 1,
     tokenURI: '',
+    transferable,
     owner: accountId
   }
 

--- a/src/components/Publish/_constants.tsx
+++ b/src/components/Publish/_constants.tsx
@@ -53,6 +53,7 @@ export const initialValues: FormPublishData = {
   },
   metadata: {
     nft: { name: '', symbol: '', description: '', image_data: '' },
+    transferable: true,
     type: 'dataset',
     name: '',
     author: '',

--- a/src/components/Publish/_types.ts
+++ b/src/components/Publish/_types.ts
@@ -29,6 +29,7 @@ export interface FormPublishData {
   }
   metadata: {
     nft: NftMetadata
+    transferable: boolean
     type: 'dataset' | 'algorithm'
     name: string
     description: string

--- a/src/components/Publish/_utils.ts
+++ b/src/components/Publish/_utils.ts
@@ -181,8 +181,7 @@ export async function transformPublishFormToDdo(
         }
       ],
       nft: {
-        ...generateNftCreateData(values?.metadata.nft, accountId),
-        owner: accountId
+        ...generateNftCreateData(values?.metadata.nft, accountId)
       }
     })
   }
@@ -199,7 +198,8 @@ export async function createTokensAndPricing(
 ) {
   const nftCreateData: NftCreateData = generateNftCreateData(
     values.metadata.nft,
-    accountId
+    accountId,
+    values.metadata.transferable
   )
   const { appConfig } = getSiteMetadata()
   LoggerInstance.log('[publish] Creating NFT with metadata', nftCreateData)


### PR DESCRIPTION
- send along `transferable` param when creating NFT
- new optional `transferable` param in our `generateNftCreateData()` helper, default to `true`. So we don't need to bother adding this to the publish tx fee component
- capture new key in form data, `metadata.transferable`, set to `true` by default. This prepares this to be added as a UI option later on