### PR TITLE
Change default NFT name

### DIFF
--- a/src/@utils/nft.ts
+++ b/src/@utils/nft.ts
@@ -50,7 +50,7 @@ export function generateNftMetadata(): NftMetadata {
   const imageData = `data:image/svg+xml,${encodeSvg(svg.outerHTML)}`
 
   const newNft: NftMetadata = {
-    name: 'Ocean Asset NFT',
+    name: 'Ocean Data NFT',
     symbol: 'OCEAN-NFT',
     description: `This NFT represents an asset in the Ocean Protocol v4 ecosystem.`,
     external_url: 'https://market.oceanprotocol.com',


### PR DESCRIPTION
Heard we have a specific name for this, so staying consistent with what we put on chain too.

- Ocean Asset NFT → Ocean Data NFT