### PR TITLE
Showing connect wallet button on submit page when no wallet is connected

### DIFF
--- a/src/components/Publish/Actions/index.tsx
+++ b/src/components/Publish/Actions/index.tsx
@@ -21,8 +21,7 @@ export default function Actions({
     isSubmitting,
     setFieldValue
   }: FormikContextType<FormPublishData> = useFormikContext()
-
-  const { connect } = useWeb3()
+  const { connect, accountId } = useWeb3()
 
   async function handleActivation(e: FormEvent<HTMLButtonElement>) {
     // prevent accidentially submitting a form the button might be in
@@ -75,12 +74,16 @@ export default function Actions({
             >
               Continue
             </Button>
-          ) : values.user.accountId === '' || !isValid ? (
+          ) : !accountId ? (
             <Button type="submit" style="primary" onClick={handleActivation}>
               Connect Wallet
             </Button>
           ) : (
-            <Button type="submit" style="primary" disabled={isSubmitting}>
+            <Button
+              type="submit"
+              style="primary"
+              disabled={isSubmitting || !isValid}
+            >
               Submit
             </Button>
           )}

--- a/src/components/Publish/Actions/index.tsx
+++ b/src/components/Publish/Actions/index.tsx
@@ -5,6 +5,7 @@ import { FormikContextType, useFormikContext } from 'formik'
 import { FormPublishData } from '../_types'
 import { wizardSteps } from '../_constants'
 import SuccessConfetti from '@shared/SuccessConfetti'
+import { useWeb3 } from '../../../@context/Web3'
 
 export default function Actions({
   scrollToRef,
@@ -20,6 +21,15 @@ export default function Actions({
     isSubmitting,
     setFieldValue
   }: FormikContextType<FormPublishData> = useFormikContext()
+
+  const { connect } = useWeb3()
+
+  async function handleActivation(e: FormEvent<HTMLButtonElement>) {
+    // prevent accidentially submitting a form the button might be in
+    e.preventDefault()
+
+    await connect()
+  }
 
   function handleNext(e: FormEvent) {
     e.preventDefault()
@@ -65,14 +75,12 @@ export default function Actions({
             >
               Continue
             </Button>
+          ) : values.user.accountId === '' || !isValid ? (
+            <Button type="submit" style="primary" onClick={handleActivation}>
+              Connect Wallet
+            </Button>
           ) : (
-            <Button
-              type="submit"
-              style="primary"
-              disabled={
-                values.user.accountId === '' || !isValid || isSubmitting
-              }
-            >
+            <Button type="submit" style="primary" disabled={isSubmitting}>
               Submit
             </Button>
           )}


### PR DESCRIPTION
Fixes #1320 

Changes proposed in this PR:

- Showing connect wallet button on submit page when no wallet is connected