### PR TITLE
Improve footer links

### DIFF
--- a/content/site.json
+++ b/content/site.json
@@ -3,7 +3,7 @@
   "siteTagline": "A marketplace to find, publish and trade data sets in the Ocean Network.",
   "siteUrl": "https://v4.market.oceanprotocol.com",
   "siteImage": "/share.png",
-  "copyright": "All Rights Reserved. Powered by [Ocean Protocol](https://oceanprotocol.com)",
+  "copyright": "All Rights Reserved. Powered by ",
   "menu": [
     {
       "name": "Publish",

--- a/src/components/Footer/Footer.module.css
+++ b/src/components/Footer/Footer.module.css
@@ -55,3 +55,15 @@
     text-align: right;
   }
 }
+.grid a {
+  text-transform: none;
+  font-family: var(--font-family-base);
+  font-weight: var(--font-weight-base);
+}
+
+.svg {
+  display: inline;
+  fill: currentColor;
+  width: 0.6em;
+  height: 0.6em;
+}

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -5,6 +5,8 @@ import { useSiteMetadata } from '@hooks/useSiteMetadata'
 import MarketStats from './MarketStats'
 import BuildId from './BuildId'
 import Links from './Links'
+import Button from '@shared/atoms/Button'
+import External from '@images/external.svg'
 
 export default function Footer(): ReactElement {
   const { copyright } = useSiteMetadata()
@@ -19,6 +21,14 @@ export default function Footer(): ReactElement {
         <Links />
         <div className={styles.copyright}>
           © {year} <Markdown text={copyright} />
+          <Button
+            style="text"
+            size="small"
+            href="https://oceanprotocol.com"
+            target="_blank"
+          >
+            Ocean Protocol <External className={styles.svg} />
+          </Button>
         </div>
       </div>
     </footer>

--- a/src/components/Footer/Links.tsx
+++ b/src/components/Footer/Links.tsx
@@ -17,7 +17,7 @@ export default function Links() {
     <div className={styles.links}>
       {content.links.map(({ name, url }) => (
         <Fragment key={name}>
-          <Button style="text" size="small" href={url}>
+          <Button style="text" size="small" href={url} target="_blank">
             {name} <External />
           </Button>
           {' — '}


### PR DESCRIPTION
Fixes #1337 

Changes proposed in this PR:

- External links now open in a new tab
- Adding the external link SVG icon to the Ocean Protocol main site link
- Main site link also opens in a new tab

## Screenshot:

![Updated main site link - 2022-04-11_15-25](https://user-images.githubusercontent.com/20739535/162738818-571ff518-8f5b-46cd-afe3-40121de01104.png)


