### PR TITLE
Add reuse order in start compute flow 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@coingecko/cryptoformat": "^0.4.4",
         "@loadable/component": "^5.15.2",
         "@oceanprotocol/art": "^3.2.0",
-        "@oceanprotocol/lib": "^1.0.0-next.36",
+        "@oceanprotocol/lib": "^1.0.0-next.37",
         "@oceanprotocol/typographies": "^0.1.0",
         "@portis/web3": "^4.0.7",
         "@tippyjs/react": "^4.2.6",
@@ -2723,9 +2723,9 @@
       "integrity": "sha512-M/yyKfpWmMRHWPTjvKlrRWUcIbfkRWyHhjHUI1kPggJPPX6ADxApTwtzwVXJ/+WyegcaYc7bqwuclqvg9XPqBQ=="
     },
     "node_modules/@oceanprotocol/lib": {
-      "version": "1.0.0-next.36",
-      "resolved": "https://registry.npmjs.org/@oceanprotocol/lib/-/lib-1.0.0-next.36.tgz",
-      "integrity": "sha512-Q0IoLGSRlxAJYBc4aF9eZRdIWigD0+W1we9EVQd7nn4MJBN290VEUVlE88+ZBkjrrE4Wq7E0YGyVlsDwzMQh7Q==",
+      "version": "1.0.0-next.37",
+      "resolved": "https://registry.npmjs.org/@oceanprotocol/lib/-/lib-1.0.0-next.37.tgz",
+      "integrity": "sha512-3d3JSSZbBjPnlqzx8LJw6g+Ti4LL96FH/TTOqFCP9D4kbux2gN0KaUdHzI66G6S6vhsxBKOmUyACJcOuH3eBDQ==",
       "dependencies": {
         "@oceanprotocol/contracts": "1.0.0-alpha.28",
         "bignumber.js": "^9.0.2",
@@ -21572,15 +21572,16 @@
       "integrity": "sha512-M/yyKfpWmMRHWPTjvKlrRWUcIbfkRWyHhjHUI1kPggJPPX6ADxApTwtzwVXJ/+WyegcaYc7bqwuclqvg9XPqBQ=="
     },
     "@oceanprotocol/lib": {
-      "version": "1.0.0-next.36",
-      "resolved": "https://registry.npmjs.org/@oceanprotocol/lib/-/lib-1.0.0-next.36.tgz",
-      "integrity": "sha512-Q0IoLGSRlxAJYBc4aF9eZRdIWigD0+W1we9EVQd7nn4MJBN290VEUVlE88+ZBkjrrE4Wq7E0YGyVlsDwzMQh7Q==",
+      "version": "1.0.0-next.37",
+      "resolved": "https://registry.npmjs.org/@oceanprotocol/lib/-/lib-1.0.0-next.37.tgz",
+      "integrity": "sha512-3d3JSSZbBjPnlqzx8LJw6g+Ti4LL96FH/TTOqFCP9D4kbux2gN0KaUdHzI66G6S6vhsxBKOmUyACJcOuH3eBDQ==",
       "requires": {
         "@oceanprotocol/contracts": "1.0.0-alpha.28",
         "bignumber.js": "^9.0.2",
         "cross-fetch": "^3.1.5",
         "crypto-js": "^4.1.1",
         "decimal.js": "^10.3.1",
+        "web3": "^1.7.3",
         "web3-core": "^1.7.1",
         "web3-eth-contract": "^1.7.1"
       }
@@ -21683,6 +21684,7 @@
       "integrity": "sha512-5vwpq6kbvwkQwKqAoOU3L72GZ3Ta8RRrewKj9OJRolx28KLJJ8Dg9Rf7obRwt5jQA9bkYd8gqzMTrI7H3xLfaw==",
       "dev": true,
       "requires": {
+        "@oclif/config": "^1.15.1",
         "@oclif/errors": "^1.3.3",
         "@oclif/parser": "^3.8.3",
         "@oclif/plugin-help": "^3",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@coingecko/cryptoformat": "^0.4.4",
     "@loadable/component": "^5.15.2",
     "@oceanprotocol/art": "^3.2.0",
-    "@oceanprotocol/lib": "^1.0.0-next.36",
+    "@oceanprotocol/lib": "^1.0.0-next.37",
     "@oceanprotocol/typographies": "^0.1.0",
     "@portis/web3": "^4.0.7",
     "@tippyjs/react": "^4.2.6",

--- a/src/@utils/compute.ts
+++ b/src/@utils/compute.ts
@@ -134,6 +134,25 @@ export function getValidUntilTime(
   return Math.floor(mytime.getTime() / 1000)
 }
 
+export function getResourcesValidTime(
+  jobStartTime: string,
+  computeEnvMaxJobDuration: number,
+  datasetTimeout?: number,
+  algorithmTimeout?: number
+) {
+  const inputValues = []
+  computeEnvMaxJobDuration && inputValues.push(computeEnvMaxJobDuration * 60)
+  datasetTimeout && inputValues.push(datasetTimeout)
+  algorithmTimeout && inputValues.push(algorithmTimeout)
+
+  const minValue = Math.min(...inputValues)
+  console.log('jobStartTime', jobStartTime)
+  const jobStartDate = new Date(jobStartTime)
+  console.log('jobStartDate', jobStartDate)
+  jobStartDate.setMinutes(jobStartDate.getMinutes() + Math.floor(minValue / 60))
+  return Math.floor(jobStartDate.getTime() / 1000)
+}
+
 export async function getComputeEnviroment(
   asset: Asset
 ): Promise<ComputeEnvironment> {

--- a/src/@utils/compute.ts
+++ b/src/@utils/compute.ts
@@ -148,6 +148,7 @@ export async function checkComputeResourcesValidity(
     asset,
     cancelToken
   )
+  if (jobs.computeJobs.length <= 0) return false
   const inputValues = []
   computeEnvMaxJobDuration && inputValues.push(computeEnvMaxJobDuration * 60)
   datasetTimeout && inputValues.push(datasetTimeout)

--- a/src/@utils/compute.ts
+++ b/src/@utils/compute.ts
@@ -134,23 +134,31 @@ export function getValidUntilTime(
   return Math.floor(mytime.getTime() / 1000)
 }
 
-export function getResourcesValidTime(
-  jobStartTime: string,
+export async function checkComputeResourcesValidity(
+  asset: Asset,
+  accountId: string,
   computeEnvMaxJobDuration: number,
   datasetTimeout?: number,
-  algorithmTimeout?: number
-) {
+  algorithmTimeout?: number,
+  cancelToken?: CancelToken
+): Promise<boolean> {
+  const jobs = await getComputeJobs(
+    [asset?.chainId],
+    accountId,
+    asset,
+    cancelToken
+  )
   const inputValues = []
   computeEnvMaxJobDuration && inputValues.push(computeEnvMaxJobDuration * 60)
   datasetTimeout && inputValues.push(datasetTimeout)
   algorithmTimeout && inputValues.push(algorithmTimeout)
-
   const minValue = Math.min(...inputValues)
-  console.log('jobStartTime', jobStartTime)
-  const jobStartDate = new Date(jobStartTime)
-  console.log('jobStartDate', jobStartDate)
+  const jobStartDate = new Date(
+    parseInt(jobs.computeJobs[0].dateCreated) * 1000
+  )
   jobStartDate.setMinutes(jobStartDate.getMinutes() + Math.floor(minValue / 60))
-  return Math.floor(jobStartDate.getTime() / 1000)
+  const currentTime = new Date().getTime() / 1000
+  return Math.floor(jobStartDate.getTime() / 1000) > currentTime
 }
 
 export async function getComputeEnviroment(

--- a/src/@utils/compute.ts
+++ b/src/@utils/compute.ts
@@ -134,34 +134,6 @@ export function getValidUntilTime(
   return Math.floor(mytime.getTime() / 1000)
 }
 
-export async function checkComputeResourcesValidity(
-  asset: Asset,
-  accountId: string,
-  computeEnvMaxJobDuration: number,
-  datasetTimeout?: number,
-  algorithmTimeout?: number,
-  cancelToken?: CancelToken
-): Promise<boolean> {
-  const jobs = await getComputeJobs(
-    [asset?.chainId],
-    accountId,
-    asset,
-    cancelToken
-  )
-  if (jobs.computeJobs.length <= 0) return false
-  const inputValues = []
-  computeEnvMaxJobDuration && inputValues.push(computeEnvMaxJobDuration * 60)
-  datasetTimeout && inputValues.push(datasetTimeout)
-  algorithmTimeout && inputValues.push(algorithmTimeout)
-  const minValue = Math.min(...inputValues)
-  const jobStartDate = new Date(
-    parseInt(jobs.computeJobs[0].dateCreated) * 1000
-  )
-  jobStartDate.setMinutes(jobStartDate.getMinutes() + Math.floor(minValue / 60))
-  const currentTime = new Date().getTime() / 1000
-  return Math.floor(jobStartDate.getTime() / 1000) > currentTime
-}
-
 export async function getComputeEnviroment(
   asset: Asset
 ): Promise<ComputeEnvironment> {
@@ -396,4 +368,32 @@ export async function transformComputeFormToServiceComputeOptions(
   }
 
   return privacy
+}
+
+export async function checkComputeResourcesValidity(
+  asset: Asset,
+  accountId: string,
+  computeEnvMaxJobDuration: number,
+  datasetTimeout?: number,
+  algorithmTimeout?: number,
+  cancelToken?: CancelToken
+): Promise<boolean> {
+  const jobs = await getComputeJobs(
+    [asset?.chainId],
+    accountId,
+    asset,
+    cancelToken
+  )
+  if (jobs.computeJobs.length <= 0) return false
+  const inputValues = []
+  computeEnvMaxJobDuration && inputValues.push(computeEnvMaxJobDuration * 60)
+  datasetTimeout && inputValues.push(datasetTimeout)
+  algorithmTimeout && inputValues.push(algorithmTimeout)
+  const minValue = Math.min(...inputValues)
+  const jobStartDate = new Date(
+    parseInt(jobs.computeJobs[0].dateCreated) * 1000
+  )
+  jobStartDate.setMinutes(jobStartDate.getMinutes() + Math.floor(minValue / 60))
+  const currentTime = new Date().getTime() / 1000
+  return Math.floor(jobStartDate.getTime() / 1000) > currentTime
 }

--- a/src/@utils/order.ts
+++ b/src/@utils/order.ts
@@ -144,11 +144,10 @@ export async function reuseOrder(
     computeEnv,
     computeValidUntil
   )
-
   const txApprove = await approve(
     web3,
     accountId,
-    asset.accessDetails.baseToken.address,
+    initializeData.providerFee.providerFeeToken,
     asset.accessDetails.datatoken.address,
     initializeData.providerFee.providerFeeAmount,
     false

--- a/src/@utils/order.ts
+++ b/src/@utils/order.ts
@@ -111,3 +111,58 @@ export async function order(
     }
   }
 }
+
+/**
+ * called when having a valid order, but with expired provider access, requires approval of the provider fee
+ * @param web3
+ * @param asset
+ * @param accountId
+ * @param accountId validOrderTx
+ * @param computeEnv
+ * @param computeValidUntil
+ * @param computeConsumerAddress
+ * @returns {TransactionReceipt} receipt of the order
+ */
+export async function reuseOrder(
+  web3: Web3,
+  asset: AssetExtended,
+  accountId: string,
+  validOrderTx: string,
+  computeEnv: string = null,
+  computeValidUntil: number = null,
+  computeConsumerAddress?: string
+) {
+  const datatoken = new Datatoken(web3)
+  const initializeData = await ProviderInstance.initialize(
+    asset.id,
+    asset.services[0].id,
+    0,
+    accountId,
+    asset.services[0].serviceEndpoint,
+    null,
+    null,
+    computeEnv,
+    computeValidUntil
+  )
+
+  const txApprove = await approve(
+    web3,
+    accountId,
+    asset.accessDetails.baseToken.address,
+    asset.accessDetails.datatoken.address,
+    initializeData.providerFee.providerFeeAmount,
+    false
+  )
+  if (!txApprove) {
+    return
+  }
+
+  const tx = await datatoken.reuseOrder(
+    asset.accessDetails.datatoken.address,
+    accountId,
+    validOrderTx,
+    initializeData.providerFee
+  )
+
+  return tx
+}

--- a/src/components/Asset/AssetActions/Compute/index.tsx
+++ b/src/components/Asset/AssetActions/Compute/index.tsx
@@ -28,7 +28,9 @@ import {
   getAlgorithmAssetSelectionList,
   getAlgorithmsForAsset,
   getValidUntilTime,
-  getComputeEnviroment
+  getComputeEnviroment,
+  getComputeJobs,
+  getResourcesValidTime
 } from '@utils/compute'
 import { AssetSelectionAsset } from '@shared/FormFields/AssetSelection'
 import AlgorithmDatasetsListForCompute from './AlgorithmDatasetsListForCompute'
@@ -177,6 +179,26 @@ export default function Compute({
     }
   }
 
+  async function checkValidProviderFees() {
+    const jobs = await getComputeJobs(
+      [asset?.chainId],
+      accountId,
+      asset,
+      newCancelToken()
+    )
+    const currentTime = new Date().getTime() / 1000
+    const jobValidFees = getResourcesValidTime(
+      parseInt(jobs.computeJobs[0].dateCreated),
+      computeEnv.maxJobDuration,
+      asset.services[0].timeout,
+      selectedAlgorithmAsset.services[0].timeout
+    )
+    console.log('route jobValidFees', jobValidFees)
+    console.log('route currentTime', currentTime)
+    if (jobs.computeJobs.length <= 0 || currentTime > jobValidFees) return
+    console.log('fees not valid')
+  }
+
   useEffect(() => {
     if (!asset?.accessDetails || !accountId) return
 
@@ -197,6 +219,7 @@ export default function Compute({
     async function initSelectedAlgo() {
       await checkAssetDTBalance(selectedAlgorithmAsset)
       await initPriceAndFees()
+      await checkValidProviderFees()
     }
 
     initSelectedAlgo()

--- a/src/components/Asset/AssetActions/Compute/index.tsx
+++ b/src/components/Asset/AssetActions/Compute/index.tsx
@@ -29,8 +29,7 @@ import {
   getAlgorithmsForAsset,
   getValidUntilTime,
   getComputeEnviroment,
-  getComputeJobs,
-  getResourcesValidTime
+  checkComputeResourcesValidity
 } from '@utils/compute'
 import { AssetSelectionAsset } from '@shared/FormFields/AssetSelection'
 import AlgorithmDatasetsListForCompute from './AlgorithmDatasetsListForCompute'
@@ -43,7 +42,7 @@ import { useAbortController } from '@hooks/useAbortController'
 import { getOrderPriceAndFees } from '@utils/accessDetailsAndPricing'
 import { OrderPriceAndFees } from 'src/@types/Price'
 import { buyDtFromPool } from '@utils/pool'
-import { order } from '@utils/order'
+import { order, reuseOrder } from '@utils/order'
 import { AssetExtended } from 'src/@types/AssetExtended'
 import { getComputeFeedback } from '@utils/feedback'
 
@@ -96,6 +95,7 @@ export default function Compute({
     useState<OrderPriceAndFees>()
   const [isRequestingAlgoOrderPrice, setIsRequestingAlgoOrderPrice] =
     useState(false)
+  const [isProviderFeeValid, setIsProviderFeeValid] = useState(false)
   const isComputeButtonDisabled =
     isJobStarting === true ||
     file === null ||
@@ -118,6 +118,15 @@ export default function Compute({
   async function initPriceAndFees() {
     const computeEnv = await getComputeEnviroment(asset)
     setComputeEnv(computeEnv)
+    setIsProviderFeeValid(
+      await checkComputeResourcesValidity(
+        asset,
+        accountId,
+        computeEnv?.maxJobDuration,
+        asset.services[0].timeout,
+        selectedAlgorithmAsset.services[0].timeout
+      )
+    )
     const validUntil = getValidUntilTime(
       computeEnv?.maxJobDuration,
       asset.services[0].timeout,
@@ -179,26 +188,6 @@ export default function Compute({
     }
   }
 
-  async function checkValidProviderFees() {
-    const jobs = await getComputeJobs(
-      [asset?.chainId],
-      accountId,
-      asset,
-      newCancelToken()
-    )
-    const currentTime = new Date().getTime() / 1000
-    const jobValidFees = getResourcesValidTime(
-      parseInt(jobs.computeJobs[0].dateCreated),
-      computeEnv.maxJobDuration,
-      asset.services[0].timeout,
-      selectedAlgorithmAsset.services[0].timeout
-    )
-    console.log('route jobValidFees', jobValidFees)
-    console.log('route currentTime', currentTime)
-    if (jobs.computeJobs.length <= 0 || currentTime > jobValidFees) return
-    console.log('fees not valid')
-  }
-
   useEffect(() => {
     if (!asset?.accessDetails || !accountId) return
 
@@ -219,7 +208,6 @@ export default function Compute({
     async function initSelectedAlgo() {
       await checkAssetDTBalance(selectedAlgorithmAsset)
       await initPriceAndFees()
-      await checkValidProviderFees()
     }
 
     initSelectedAlgo()
@@ -398,6 +386,26 @@ export default function Compute({
           toast.error('Failed to order algorithm asset!')
           return
         }
+      }
+
+      if (isOwned && !isProviderFeeValid) {
+        const reuseOrderTx = await reuseOrder(
+          web3,
+          asset,
+          accountId,
+          validOrderTx,
+          computeEnv?.id,
+          computeValidUntil
+        )
+        if (!reuseOrderTx) {
+          toast.error('Failed to pay provider fees!')
+          return
+        }
+        LoggerInstance.log(
+          '[compute] Reused order: ',
+          reuseOrderTx.transactionHash
+        )
+        datasetOrderTx = reuseOrderTx.transactionHash
       }
 
       LoggerInstance.log('[compute] Starting compute job.')


### PR DESCRIPTION
Fixes # .

Changes proposed in this PR:

- added logic to check if provider fees are still valid on an asset
- added reuse order method that is called when the order is still valid but compute resources are not 

Note: this works with a local version of oceanjs build from this PR: https://github.com/oceanprotocol/ocean.js/pull/1421 so requires a release of oceanjs to make tests green and be able to test with the vercel preview