### PR TITLE
fix opcFees before data is present

### DIFF
--- a/src/@context/MarketMetadata/index.tsx
+++ b/src/@context/MarketMetadata/index.tsx
@@ -48,7 +48,7 @@ function MarketMetadataProvider({
 
   const getOpcFeeForToken = useCallback(
     (tokenAddress: string, chainId: number): string => {
-      if (!opcFees) return
+      if (!opcFees) return '0'
 
       const opc = opcFees.filter((x) => x.chainId === chainId)[0]
       const isTokenApproved = opc.approvedTokens.includes(tokenAddress)


### PR DESCRIPTION
`getOpcFeeForToken` needs `opcFees` but if it returns `null` (testing on hotel wifi really helps running into that), many successive usages of method just fail, resulting in app error.

So just return `'0'` until we have data