### PR TITLE
restore order for assets with fixed pricing

### DIFF
--- a/src/@utils/accessDetailsAndPricing.ts
+++ b/src/@utils/accessDetailsAndPricing.ts
@@ -256,6 +256,7 @@ export async function getOrderPriceAndFees(
     asset?.services[0].serviceEndpoint
   )
   orderPriceAndFee.providerFee = initializeData.providerFee
+  if (!orderPriceAndFee.providerFee) return
 
   // fetch price and swap fees
   switch (asset?.accessDetails?.type) {

--- a/src/components/Asset/AssetActions/Compute/index.tsx
+++ b/src/components/Asset/AssetActions/Compute/index.tsx
@@ -420,11 +420,7 @@ export default function Compute({
             assetTimeout={datasetTimeout}
             hasPreviousOrderSelectedComputeAsset={hasPreviousAlgorithmOrder}
             hasDatatokenSelectedComputeAsset={hasAlgoAssetDatatoken}
-            oceanSymbol={
-              accessDetails?.baseToken?.symbol
-                ? accessDetails.baseToken.symbol
-                : ''
-            }
+            oceanSymbol={accessDetails?.baseToken?.symbol || ''}
             dtSymbolSelectedComputeAsset={
               selectedAlgorithmAsset?.datatokens[0]?.symbol
             }

--- a/src/components/Asset/AssetActions/Compute/index.tsx
+++ b/src/components/Asset/AssetActions/Compute/index.tsx
@@ -420,7 +420,11 @@ export default function Compute({
             assetTimeout={datasetTimeout}
             hasPreviousOrderSelectedComputeAsset={hasPreviousAlgorithmOrder}
             hasDatatokenSelectedComputeAsset={hasAlgoAssetDatatoken}
-            oceanSymbol={accessDetails ? accessDetails.baseToken.symbol : ''}
+            oceanSymbol={
+              accessDetails?.baseToken?.symbol
+                ? accessDetails.baseToken.symbol
+                : ''
+            }
             dtSymbolSelectedComputeAsset={
               selectedAlgorithmAsset?.datatokens[0]?.symbol
             }

--- a/src/components/Asset/AssetActions/Download.tsx
+++ b/src/components/Asset/AssetActions/Download.tsx
@@ -60,7 +60,8 @@ export default function Download({
       if (
         asset?.accessDetails?.addressOrId === ZERO_ADDRESS ||
         asset?.accessDetails?.type === 'free' ||
-        (!poolData && asset?.accessDetails?.type === 'dynamic')
+        (!poolData && asset?.accessDetails?.type === 'dynamic') ||
+        !poolData
       )
         return
       setIsLoading(true)
@@ -82,7 +83,6 @@ export default function Download({
       )
 
       setOrderPriceAndFees(orderPriceAndFees)
-
       setIsLoading(false)
     }
 

--- a/src/components/Asset/AssetActions/Download.tsx
+++ b/src/components/Asset/AssetActions/Download.tsx
@@ -71,11 +71,17 @@ export default function Download({
         tokenInLiquidity: poolData?.baseTokenLiquidity,
         tokenOutLiquidity: poolData?.datatokenLiquidity,
         tokenOutAmount: '1',
-        opcFee: getOpcFeeForToken(poolData.baseToken.address, asset?.chainId),
+        opcFee: getOpcFeeForToken(
+          poolData?.baseToken?.address
+            ? poolData?.baseToken?.address
+            : asset?.accessDetails?.addressOrId,
+          asset?.chainId
+        ),
         lpSwapFee: poolData?.liquidityProviderSwapFee,
         publishMarketSwapFee: poolData?.publishMarketSwapFee,
         consumeMarketSwapFee: '0'
       }
+
       const orderPriceAndFees = await getOrderPriceAndFees(
         asset,
         ZERO_ADDRESS,
@@ -87,7 +93,7 @@ export default function Download({
     }
 
     init()
-  }, [asset, accountId, poolData, getOpcFeeForToken, isLoading])
+  }, [asset, accountId, poolData, getOpcFeeForToken])
 
   useEffect(() => {
     setHasDatatoken(Number(dtBalance) >= 1)
@@ -146,6 +152,7 @@ export default function Download({
         if (!orderTx) {
           throw new Error()
         }
+
         setIsOwned(true)
         setValidOrderTx(orderTx.transactionHash)
       }

--- a/src/components/Asset/AssetActions/Download.tsx
+++ b/src/components/Asset/AssetActions/Download.tsx
@@ -72,9 +72,7 @@ export default function Download({
         tokenOutLiquidity: poolData?.datatokenLiquidity,
         tokenOutAmount: '1',
         opcFee: getOpcFeeForToken(
-          poolData?.baseToken?.address
-            ? poolData?.baseToken?.address
-            : asset?.accessDetails?.addressOrId,
+          poolData?.baseToken?.address || asset?.accessDetails?.addressOrId,
           asset?.chainId
         ),
         lpSwapFee: poolData?.liquidityProviderSwapFee,
@@ -89,7 +87,9 @@ export default function Download({
       )
 
       setOrderPriceAndFees(orderPriceAndFees)
-      setIsDisabled(false)
+      if (isAssetNetwork) {
+        setIsDisabled(false)
+      }
     }
 
     init()
@@ -104,7 +104,9 @@ export default function Download({
 
     const isDisabled =
       !asset?.accessDetails.isPurchasable ||
+      !isAssetNetwork ||
       ((!isBalanceSufficient || !isAssetNetwork) && !isOwned && !hasDatatoken)
+
     setIsDisabled(isDisabled)
   }, [
     isMounted,

--- a/src/components/Asset/AssetActions/Download.tsx
+++ b/src/components/Asset/AssetActions/Download.tsx
@@ -61,9 +61,7 @@ export default function Download({
       if (
         asset?.accessDetails?.addressOrId === ZERO_ADDRESS ||
         asset?.accessDetails?.type === 'free' ||
-        (!poolData && asset?.accessDetails?.type === 'dynamic') ||
-        // Stop refetching price and fees when asset is being accessed
-        isLoading
+        (!poolData && asset?.accessDetails?.type === 'dynamic')
       )
         return
 
@@ -87,12 +85,13 @@ export default function Download({
       )
 
       setOrderPriceAndFees(orderPriceAndFees)
-      if (isAssetNetwork) {
-        setIsDisabled(false)
-      }
     }
 
     init()
+    /**
+     * we listen to the assets' changes to get the most updated price
+     * based on the asset and the poolData's information
+     */
   }, [asset, accountId, poolData, getOpcFeeForToken])
 
   useEffect(() => {
@@ -102,6 +101,13 @@ export default function Download({
   useEffect(() => {
     if (!isMounted || !accountId || !asset?.accessDetails) return
 
+    /**
+     * disabled in these cases:
+     * - if the asset is not purchasable
+     * - if the user is on the wrong network
+     * - if user balance is not sufficient
+     * - if user has no datatokens
+     */
     const isDisabled =
       !asset?.accessDetails.isPurchasable ||
       !isAssetNetwork ||


### PR DESCRIPTION
- Fixes #1356 .
- Fixes #1364 
- Fixes #1363 

Changes proposed in this PR:

- restore order for fixed pricing
- restore download button after purchase
- disable download/buy button if the user is on network different as the asset's