### PR TITLE
Converting accountId and owner to lowercase for the comparison to avoid problems caused by inconsistent cases

### DIFF
--- a/src/components/Asset/Edit/index.tsx
+++ b/src/components/Asset/Edit/index.tsx
@@ -39,7 +39,7 @@ export default function Edit({ uri }: { uri: string }): ReactElement {
 
   return asset &&
     asset?.accessDetails &&
-    accountId.toLowerCase() === owner.toLowerCase() ? (
+    accountId?.toLowerCase() === owner?.toLowerCase() ? (
     <Page title={pageTitle} noPageHeader uri={uri}>
       <div className={styles.container}>
         <Tabs items={tabs} defaultIndex={0} className={styles.edit} />
@@ -47,9 +47,7 @@ export default function Edit({ uri }: { uri: string }): ReactElement {
     </Page>
   ) : asset &&
     asset?.accessDetails &&
-    accountId &&
-    owner &&
-    accountId.toLowerCase() !== owner.toLowerCase() ? (
+    accountId?.toLowerCase() !== owner?.toLowerCase() ? (
     <Page title={pageTitle} noPageHeader uri={uri}>
       <Alert
         title="Edit action available only to asset owner"

--- a/src/components/Asset/Edit/index.tsx
+++ b/src/components/Asset/Edit/index.tsx
@@ -37,23 +37,27 @@ export default function Edit({ uri }: { uri: string }): ReactElement {
     }
   ].filter((tab) => tab !== undefined)
 
-  return !asset || !accountId || !owner || !asset?.accessDetails ? (
-    <Page title={pageTitle} noPageHeader uri={uri}>
-      <Loader />
-    </Page>
-  ) : accountId === owner ? (
+  return asset && asset?.accessDetails && accountId === owner ? (
     <Page title={pageTitle} noPageHeader uri={uri}>
       <div className={styles.container}>
         <Tabs items={tabs} defaultIndex={0} className={styles.edit} />
       </div>
     </Page>
-  ) : (
+  ) : asset &&
+    asset?.accessDetails &&
+    accountId &&
+    owner &&
+    accountId !== owner ? (
     <Page title={pageTitle} noPageHeader uri={uri}>
       <Alert
         title="Edit action available only to asset owner"
         text={error}
         state="error"
       />
+    </Page>
+  ) : (
+    <Page title={pageTitle} noPageHeader uri={uri}>
+      <Loader />
     </Page>
   )
 }

--- a/src/components/Asset/Edit/index.tsx
+++ b/src/components/Asset/Edit/index.tsx
@@ -37,23 +37,23 @@ export default function Edit({ uri }: { uri: string }): ReactElement {
     }
   ].filter((tab) => tab !== undefined)
 
-  return asset && asset?.accessDetails && accountId === owner ? (
+  return !asset || !accountId || !owner || !asset?.accessDetails ? (
+    <Page title={pageTitle} noPageHeader uri={uri}>
+      <Loader />
+    </Page>
+  ) : accountId === owner ? (
     <Page title={pageTitle} noPageHeader uri={uri}>
       <div className={styles.container}>
         <Tabs items={tabs} defaultIndex={0} className={styles.edit} />
       </div>
     </Page>
-  ) : asset && asset?.accessDetails && accountId !== owner ? (
+  ) : (
     <Page title={pageTitle} noPageHeader uri={uri}>
       <Alert
         title="Edit action available only to asset owner"
         text={error}
         state="error"
       />
-    </Page>
-  ) : (
-    <Page title={pageTitle} noPageHeader uri={uri}>
-      <Loader />
     </Page>
   )
 }

--- a/src/components/Asset/Edit/index.tsx
+++ b/src/components/Asset/Edit/index.tsx
@@ -37,7 +37,9 @@ export default function Edit({ uri }: { uri: string }): ReactElement {
     }
   ].filter((tab) => tab !== undefined)
 
-  return asset && asset?.accessDetails && accountId === owner ? (
+  return asset &&
+    asset?.accessDetails &&
+    accountId.toLowerCase() === owner.toLowerCase() ? (
     <Page title={pageTitle} noPageHeader uri={uri}>
       <div className={styles.container}>
         <Tabs items={tabs} defaultIndex={0} className={styles.edit} />
@@ -47,7 +49,7 @@ export default function Edit({ uri }: { uri: string }): ReactElement {
     asset?.accessDetails &&
     accountId &&
     owner &&
-    accountId !== owner ? (
+    accountId.toLowerCase() !== owner.toLowerCase() ? (
     <Page title={pageTitle} noPageHeader uri={uri}>
       <Alert
         title="Edit action available only to asset owner"


### PR DESCRIPTION
Fixes #1377

Changes proposed in this PR:

- Converting accountId and owner to lowercase for the comparison to avoid problems caused by inconsistent cases