### PR TITLE
Removing "no price set message"

### DIFF
--- a/src/components/@shared/Price/index.tsx
+++ b/src/components/@shared/Price/index.tsx
@@ -18,7 +18,6 @@ export default function Price({
   conversion?: boolean
   size?: 'small' | 'mini' | 'large'
 }): ReactElement {
-  console.log('accessDetails?.type', accessDetails?.type)
   return accessDetails?.price || accessDetails?.type === 'free' ? (
     <PriceUnit
       price={`${orderPriceAndFees?.price || accessDetails?.price}`}

--- a/src/components/@shared/Price/index.tsx
+++ b/src/components/@shared/Price/index.tsx
@@ -18,6 +18,7 @@ export default function Price({
   conversion?: boolean
   size?: 'small' | 'mini' | 'large'
 }): ReactElement {
+  console.log('accessDetails?.type', accessDetails?.type)
   return accessDetails?.price || accessDetails?.type === 'free' ? (
     <PriceUnit
       price={`${orderPriceAndFees?.price || accessDetails?.price}`}
@@ -27,7 +28,7 @@ export default function Price({
       conversion={conversion}
       type={accessDetails.type}
     />
-  ) : !accessDetails || accessDetails?.type === '' ? (
+  ) : accessDetails && !accessDetails.type ? (
     <div className={styles.empty}>
       No price set{' '}
       <Tooltip content="No pricing mechanism has been set on this asset yet." />

--- a/src/components/@shared/Price/index.tsx
+++ b/src/components/@shared/Price/index.tsx
@@ -27,18 +27,7 @@ export default function Price({
       conversion={conversion}
       type={accessDetails.type}
     />
-  ) : accessDetails && !accessDetails.type ? (
-    <div className={styles.empty}>
-      No price set{' '}
-      <Tooltip content="No pricing mechanism has been set on this asset yet." />
-    </div>
   ) : (
-    // TODO: Hacky hack, put back some check for low liquidity
-    // ) : price.isConsumable !== 'true' ? (
-    //   <div className={styles.empty}>
-    //     Low liquidity{' '}
-    //     <Tooltip content="This pool does not have enough liquidity for using this data set." />
-    //   </div>
     <Loader message="Retrieving price..." />
   )
 }


### PR DESCRIPTION
### Issue
For a brief moment before the prices have loaded the assets show "No price set" and then it's replaced by the actual price. This is distracting and confusing. 

![Screenshot from 2022-05-02 13-41-20](https://user-images.githubusercontent.com/20739535/166222499-98383fea-5542-4a9e-9cf3-e93fb2b5188c.png)

The same thing also happens on the asset detail page. Showing "No price set" when it's actually just loading. This creates a poor user experience and the initial impression is that it looks like it's not working.   

![Screenshot from 2022-05-02 13-47-21](https://user-images.githubusercontent.com/20739535/166222746-8a8ab488-858d-48ae-92ea-51acedee3746.png)

### Changes proposed in this  PR

- Removing the "No price set"  message. Given the new publish flow we shouldn't really have any assets without a price.