### PR TITLE
fix alignment based button on action type

### DIFF
--- a/src/components/@shared/ButtonBuy/index.module.css
+++ b/src/components/@shared/ButtonBuy/index.module.css
@@ -3,6 +3,11 @@
   margin-top: calc(var(--spacer) / 2);
 }
 
+.actionsCenter {
+  margin: auto !important;
+  display: block;
+}
+
 .help {
   font-size: var(--font-size-mini);
   color: var(--color-secondary);

--- a/src/components/@shared/ButtonBuy/index.tsx
+++ b/src/components/@shared/ButtonBuy/index.tsx
@@ -161,7 +161,7 @@ export default function ButtonBuy({
             type={type}
             onClick={onClick}
             disabled={disabled}
-            className={action === 'compute' ? 'center' : 'left'}
+            className={action === 'compute' ? styles.actionsCenter : ''}
           >
             {buttonText}
           </Button>

--- a/src/components/@shared/ButtonBuy/index.tsx
+++ b/src/components/@shared/ButtonBuy/index.tsx
@@ -161,7 +161,7 @@ export default function ButtonBuy({
             type={type}
             onClick={onClick}
             disabled={disabled}
-            className="center"
+            className={action === 'compute' ? 'center' : 'left'}
           >
             {buttonText}
           </Button>

--- a/src/components/@shared/atoms/Button/index.module.css
+++ b/src/components/@shared/atoms/Button/index.module.css
@@ -82,11 +82,6 @@
   min-width: auto;
 }
 
-.center {
-  margin: auto !important;
-  display: block;
-}
-
 /* Size Modifiers */
 .small {
   font-size: var(--font-size-small);


### PR DESCRIPTION
Changes proposed in this PR:

- fix alignment button based on action type

Before
<img width="287" alt="Screen Shot 2022-06-07 at 5 39 41 AM" src="https://user-images.githubusercontent.com/13741335/172349680-d7211882-a2a2-406e-8ccc-8d1b69a5fff5.png">

After
<img width="276" alt="Screen Shot 2022-06-07 at 5 39 49 AM" src="https://user-images.githubusercontent.com/13741335/172349724-99964722-389c-485f-ac43-620bb0d56336.png">

The rest should stay the same
<img width="274" alt="Screen Shot 2022-06-07 at 5 40 04 AM" src="https://user-images.githubusercontent.com/13741335/172349770-055a4d97-8952-442d-b48b-9a37eff75bd4.png">
