### PR TITLE
Retry failed transactions during publish

### DIFF
--- a/src/components/@shared/atoms/Button/index.module.css
+++ b/src/components/@shared/atoms/Button/index.module.css
@@ -20,15 +20,6 @@
   text-align: center;
 }
 
-.button:first-child {
-  margin-left: 0;
-}
-
-.button:last-child {
-  margin-right: 0;
-  min-width: auto;
-}
-
 .button:hover,
 .button:focus {
   color: var(--brand-white);

--- a/src/components/@shared/atoms/Loader/index.module.css
+++ b/src/components/@shared/atoms/Loader/index.module.css
@@ -23,6 +23,11 @@
   margin-left: calc(var(--spacer) / 4);
 }
 
+.loader.white {
+  border-color: rgba(255 255 255 / 0.3);
+  border-top-color: var(--brand-white);
+}
+
 @keyframes loader {
   to {
     transform: rotate(360deg);

--- a/src/components/@shared/atoms/Loader/index.tsx
+++ b/src/components/@shared/atoms/Loader/index.tsx
@@ -3,12 +3,13 @@ import styles from './index.module.css'
 
 export interface LoaderProps {
   message?: string
+  white?: boolean
 }
 
-export default function Loader({ message }: LoaderProps): ReactElement {
+export default function Loader({ message, white }: LoaderProps): ReactElement {
   return (
     <div className={styles.loaderWrap}>
-      <span className={styles.loader} />
+      <span className={`${styles.loader} ${white ? styles.white : ''}`} />
       {message && <span className={styles.message}>{message}</span>}
     </div>
   )

--- a/src/components/Publish/Actions/index.module.css
+++ b/src/components/Publish/Actions/index.module.css
@@ -7,6 +7,7 @@
 
 .actions button {
   margin: 0 calc(var(--spacer) / 2);
+  min-height: 40px;
 }
 
 .infoIcon {

--- a/src/components/Publish/Actions/index.tsx
+++ b/src/components/Publish/Actions/index.tsx
@@ -60,9 +60,9 @@ export default function Actions({
     (values.user.stepCurrent === 3 && errors.pricing !== undefined)
 
   const hasSubmitError =
-    values.feedback[1].status === 'error' ||
-    values.feedback[2].status === 'error' ||
-    values.feedback[3].status === 'error'
+    values.feedback?.[1].status === 'error' ||
+    values.feedback?.[2].status === 'error' ||
+    values.feedback?.[3].status === 'error'
 
   return (
     <footer className={styles.actions}>

--- a/src/components/Publish/Actions/index.tsx
+++ b/src/components/Publish/Actions/index.tsx
@@ -24,8 +24,7 @@ export default function Actions({
     values,
     errors,
     isValid,
-    isSubmitting,
-    setFieldValue
+    isSubmitting
   }: FormikContextType<FormPublishData> = useFormikContext()
   const { connect, accountId } = useWeb3()
 

--- a/src/components/Publish/Actions/index.tsx
+++ b/src/components/Publish/Actions/index.tsx
@@ -59,6 +59,11 @@ export default function Actions({
     (values.user.stepCurrent === 2 && errors.services !== undefined) ||
     (values.user.stepCurrent === 3 && errors.pricing !== undefined)
 
+  const hasSubmitError =
+    values.feedback[1].status === 'error' ||
+    values.feedback[2].status === 'error' ||
+    values.feedback[3].status === 'error'
+
   return (
     <footer className={styles.actions}>
       {did ? (
@@ -107,7 +112,7 @@ export default function Actions({
               style="primary"
               disabled={isSubmitting || !isValid}
             >
-              Submit
+              {hasSubmitError ? 'Retry' : 'Submit'}
             </Button>
           )}
         </>

--- a/src/components/Publish/Actions/index.tsx
+++ b/src/components/Publish/Actions/index.tsx
@@ -10,6 +10,7 @@ import { useRouter } from 'next/router'
 import Tooltip from '@shared/atoms/Tooltip'
 import AvailableNetworks from 'src/components/Publish/AvailableNetworks'
 import Info from '@images/info.svg'
+import Loader from '@shared/atoms/Loader'
 
 export default function Actions({
   scrollToRef,
@@ -112,7 +113,13 @@ export default function Actions({
               style="primary"
               disabled={isSubmitting || !isValid}
             >
-              {hasSubmitError ? 'Retry' : 'Submit'}
+              {isSubmitting ? (
+                <Loader white />
+              ) : hasSubmitError ? (
+                'Retry'
+              ) : (
+                'Submit'
+              )}
             </Button>
           )}
         </>

--- a/src/components/Publish/Submission/index.tsx
+++ b/src/components/Publish/Submission/index.tsx
@@ -1,12 +1,8 @@
 import React, { ReactElement } from 'react'
 import styles from './index.module.css'
-import { FormPublishData } from '../_types'
-import { useFormikContext } from 'formik'
 import { Feedback } from './Feedback'
 
 export default function Submission(): ReactElement {
-  const { values, handleSubmit } = useFormikContext<FormPublishData>()
-
   return (
     <div className={styles.submission}>
       <Feedback />

--- a/src/components/Publish/index.tsx
+++ b/src/components/Publish/index.tsx
@@ -11,7 +11,7 @@ import Actions from './Actions'
 import Debug from './Debug'
 import Navigation from './Navigation'
 import { Steps } from './Steps'
-import { FormPublishData, PublishFeedback } from './_types'
+import { FormPublishData } from './_types'
 import { useUserPreferences } from '@context/UserPreferences'
 import useNftFactory from '@hooks/contracts/useNftFactory'
 import { ProviderInstance, LoggerInstance, DDO } from '@oceanprotocol/lib'
@@ -35,9 +35,7 @@ export default function PublishPage({
   const nftFactory = useNftFactory()
   const newAbortController = useAbortController()
 
-  const [feedback, setFeedback] = useState<PublishFeedback>(
-    initialPublishFeedback
-  )
+  const [feedback, setFeedback] = useState(initialPublishFeedback)
   const [erc721Address, setErc721Address] = useState<string>()
   const [datatokenAddress, setDatatokenAddress] = useState<string>()
   const [ddo, setDdo] = useState<DDO>()

--- a/src/components/Publish/index.tsx
+++ b/src/components/Publish/index.tsx
@@ -35,7 +35,11 @@ export default function PublishPage({
   const nftFactory = useNftFactory()
   const newAbortController = useAbortController()
 
+  // This `feedback` state is auto-synced into Formik context under `values.feedback`
+  // for use in other components. Syncing defined in ./Steps.tsx child component.
   const [feedback, setFeedback] = useState(initialPublishFeedback)
+
+  // Collecting output of each publish step, enabling retry of failed steps
   const [erc721Address, setErc721Address] = useState<string>()
   const [datatokenAddress, setDatatokenAddress] = useState<string>()
   const [ddo, setDdo] = useState<DDO>()
@@ -233,6 +237,7 @@ export default function PublishPage({
   // Orchestrate publishing
   // --------------------------------------------------
   async function handleSubmit(values: FormPublishData) {
+    // Syncing variables with state, enabling retry of failed steps
     let _erc721Address = erc721Address
     let _datatokenAddress = datatokenAddress
     let _ddo = ddo

--- a/src/components/Publish/index.tsx
+++ b/src/components/Publish/index.tsx
@@ -38,132 +38,139 @@ export default function PublishPage({
   const [feedback, setFeedback] = useState<PublishFeedback>(
     initialPublishFeedback
   )
+  const [erc721Address, setErc721Address] = useState<string>()
+  const [datatokenAddress, setDatatokenAddress] = useState<string>()
+  const [ddo, setDdo] = useState<DDO>()
+  const [ddoEncrypted, setDdoEncrypted] = useState<string>()
   const [did, setDid] = useState<string>()
 
   async function handleSubmit(values: FormPublishData) {
-    let _erc721Address: string,
-      _datatokenAddress: string,
-      _ddo: DDO,
-      _encryptedDdo: string
-
     // reset all feedback state
     setFeedback(initialPublishFeedback)
 
     // --------------------------------------------------
     // 1. Create NFT & datatokens & create pricing schema
+    //    Wrapped in conditional allowing method to run
+    //    multiple times.
     // --------------------------------------------------
-    try {
-      setFeedback((prevState) => ({
-        ...prevState,
-        '1': {
-          ...prevState['1'],
-          status: 'active',
-          txCount: values.pricing.type === 'dynamic' ? 2 : 1,
-          description: prevState['1'].description
+    if (!erc721Address && !datatokenAddress) {
+      try {
+        setFeedback((prevState) => ({
+          ...prevState,
+          '1': {
+            ...prevState['1'],
+            status: 'active',
+            txCount: values.pricing.type === 'dynamic' ? 2 : 1,
+            description: prevState['1'].description
+          }
+        }))
+
+        const config = getOceanConfig(chainId)
+        LoggerInstance.log('[publish] using config: ', config)
+
+        const { erc721Address, datatokenAddress, txHash } =
+          await createTokensAndPricing(
+            values,
+            accountId,
+            config,
+            nftFactory,
+            web3
+          )
+
+        const isSuccess = Boolean(erc721Address && datatokenAddress && txHash)
+        setErc721Address(erc721Address)
+        setDatatokenAddress(datatokenAddress)
+
+        LoggerInstance.log('[publish] createTokensAndPricing tx', txHash)
+        LoggerInstance.log('[publish] erc721Address', erc721Address)
+        LoggerInstance.log('[publish] datatokenAddress', datatokenAddress)
+
+        setFeedback((prevState) => ({
+          ...prevState,
+          '1': {
+            ...prevState['1'],
+            status: isSuccess ? 'success' : 'error',
+            txHash
+          }
+        }))
+      } catch (error) {
+        LoggerInstance.error('[publish] error', error.message)
+        if (error.message.length > 65) {
+          error.message = 'No Token created.'
         }
-      }))
 
-      const config = getOceanConfig(chainId)
-      LoggerInstance.log('[publish] using config: ', config)
-
-      const { erc721Address, datatokenAddress, txHash } =
-        await createTokensAndPricing(
-          values,
-          accountId,
-          config,
-          nftFactory,
-          web3
-        )
-
-      const isSuccess = Boolean(erc721Address && datatokenAddress && txHash)
-      _erc721Address = erc721Address
-      _datatokenAddress = datatokenAddress
-
-      LoggerInstance.log('[publish] createTokensAndPricing tx', txHash)
-      LoggerInstance.log('[publish] erc721Address', erc721Address)
-      LoggerInstance.log('[publish] datatokenAddress', datatokenAddress)
-
-      setFeedback((prevState) => ({
-        ...prevState,
-        '1': {
-          ...prevState['1'],
-          status: isSuccess ? 'success' : 'error',
-          txHash
-        }
-      }))
-    } catch (error) {
-      LoggerInstance.error('[publish] error', error.message)
-      if (error.message.length > 65) {
-        error.message = 'No Token created.'
+        setFeedback((prevState) => ({
+          ...prevState,
+          '1': {
+            ...prevState['1'],
+            status: 'error',
+            errorMessage: error.message,
+            description:
+              values.pricing.type === 'dynamic'
+                ? prevState['1'].description.replace(
+                    'a single transaction',
+                    'a single transaction, after an initial approve transaction'
+                  )
+                : prevState['1'].description
+          }
+        }))
       }
-
-      setFeedback((prevState) => ({
-        ...prevState,
-        '1': {
-          ...prevState['1'],
-          status: 'error',
-          errorMessage: error.message,
-          description:
-            values.pricing.type === 'dynamic'
-              ? prevState['1'].description.replace(
-                  'a single transaction',
-                  'a single transaction, after an initial approve transaction'
-                )
-              : prevState['1'].description
-        }
-      }))
     }
 
     // --------------------------------------------------
     // 2. Construct and encrypt DDO
+    //    Wrapped in conditional allowing method to run
+    //    multiple times.
     // --------------------------------------------------
-    try {
-      setFeedback((prevState) => ({
-        ...prevState,
-        '2': {
-          ...prevState['2'],
-          status: 'active'
-        }
-      }))
+    if (!ddoEncrypted) {
+      try {
+        setFeedback((prevState) => ({
+          ...prevState,
+          '2': {
+            ...prevState['2'],
+            status: 'active'
+          }
+        }))
 
-      if (!_datatokenAddress || !_erc721Address)
-        throw new Error('No NFT or Datatoken received.')
+        if (!datatokenAddress || !erc721Address)
+          throw new Error('No NFT or Datatoken received.')
 
-      const ddo = await transformPublishFormToDdo(
-        values,
-        _datatokenAddress,
-        _erc721Address
-      )
+        const ddo = await transformPublishFormToDdo(
+          values,
+          datatokenAddress,
+          erc721Address
+        )
 
-      _ddo = ddo
-      LoggerInstance.log('[publish] Got new DDO', ddo)
+        setDdo(ddo)
+        LoggerInstance.log('[publish] Got new DDO', ddo)
 
-      const encryptedResponse = await ProviderInstance.encrypt(
-        ddo,
-        values.services[0].providerUrl.url,
-        newAbortController()
-      )
-      const encryptedDdo = encryptedResponse
-      _encryptedDdo = encryptedDdo
-      LoggerInstance.log('[publish] Got encrypted DDO', encryptedDdo)
+        const encryptedResponse = await ProviderInstance.encrypt(
+          ddo,
+          values.services[0].providerUrl.url,
+          newAbortController()
+        )
+        const ddoEncrypted = encryptedResponse
+        setDdoEncrypted(ddoEncrypted)
+        LoggerInstance.log('[publish] Got encrypted DDO', ddoEncrypted)
 
-      setFeedback((prevState) => ({
-        ...prevState,
-        '2': {
-          ...prevState['2'],
-          status: encryptedDdo ? 'success' : 'error'
-        }
-      }))
-    } catch (error) {
-      LoggerInstance.error('[publish] error', error.message)
-      setFeedback((prevState) => ({
-        ...prevState,
-        '2': {
-          ...prevState['2'],
-          status: 'error',
-          errorMessage: error.message
-        }
-      }))
+        setFeedback((prevState) => ({
+          ...prevState,
+          '2': {
+            ...prevState['2'],
+            status: ddoEncrypted ? 'success' : 'error'
+          }
+        }))
+      } catch (error) {
+        LoggerInstance.error('[publish] error', error.message)
+        setFeedback((prevState) => ({
+          ...prevState,
+          '2': {
+            ...prevState['2'],
+            status: 'error',
+            errorMessage: error.message
+          }
+        }))
+      }
     }
 
     // --------------------------------------------------
@@ -178,30 +185,32 @@ export default function PublishPage({
         }
       }))
 
-      if (!_ddo || !_encryptedDdo) throw new Error('No DDO received.')
+      if (!ddo || !ddoEncrypted) throw new Error('No DDO received.')
 
       const res = await setNFTMetadataAndTokenURI(
-        _ddo,
+        ddo,
         accountId,
         web3,
         values.metadata.nft,
         newAbortController()
       )
+      if (!res?.transactionHash)
+        throw new Error(
+          'Metadata could not be written into the NFT. Please hit Submit again to retry.'
+        )
 
       LoggerInstance.log('[publish] setMetadata result', res)
-
-      const txHash = res.transactionHash
 
       setFeedback((prevState) => ({
         ...prevState,
         '3': {
           ...prevState['3'],
           status: res ? 'success' : 'error',
-          txHash
+          txHash: res?.transactionHash
         }
       }))
 
-      setDid(_ddo.id)
+      setDid(ddo.id)
     } catch (error) {
       LoggerInstance.error('[publish] error', error.message)
       setFeedback((prevState) => ({

--- a/src/components/Publish/index.tsx
+++ b/src/components/Publish/index.tsx
@@ -72,8 +72,7 @@ export default function PublishPage({
         )
 
       const isSuccess = Boolean(erc721Address && datatokenAddress && txHash)
-      if (!isSuccess)
-        throw new Error('No Token created. Please hit Submit again to retry.')
+      if (!isSuccess) throw new Error('No Token created. Please try again.')
 
       LoggerInstance.log('[publish] createTokensAndPricing tx', txHash)
       LoggerInstance.log('[publish] erc721Address', erc721Address)
@@ -92,7 +91,7 @@ export default function PublishPage({
     } catch (error) {
       LoggerInstance.error('[publish] error', error.message)
       if (error.message.length > 65) {
-        error.message = 'No Token created. Please hit Submit again to retry.'
+        error.message = 'No Token created. Please try again.'
       }
 
       setFeedback((prevState) => ({
@@ -125,9 +124,7 @@ export default function PublishPage({
 
     try {
       if (!datatokenAddress || !erc721Address)
-        throw new Error(
-          'No NFT or Datatoken received. Please hit Submit again to retry.'
-        )
+        throw new Error('No NFT or Datatoken received. Please try again.')
 
       const ddo = await transformPublishFormToDdo(
         values,
@@ -135,7 +132,8 @@ export default function PublishPage({
         erc721Address
       )
 
-      if (!ddo) throw new Error('No DDO received.')
+      if (!ddo) throw new Error('No DDO received. Please try again.')
+
       setDdo(ddo)
       LoggerInstance.log('[publish] Got new DDO', ddo)
 
@@ -145,7 +143,9 @@ export default function PublishPage({
         newAbortController()
       )
 
-      if (!ddoEncrypted) throw new Error('No encrypted DDO received.')
+      if (!ddoEncrypted)
+        throw new Error('No encrypted DDO received. Please try again.')
+
       setDdoEncrypted(ddoEncrypted)
       LoggerInstance.log('[publish] Got encrypted DDO', ddoEncrypted)
 
@@ -189,7 +189,8 @@ export default function PublishPage({
     }))
 
     try {
-      if (!ddo || !ddoEncrypted) throw new Error('No DDO received.')
+      if (!ddo || !ddoEncrypted)
+        throw new Error('No DDO received. Please try again.')
 
       const res = await setNFTMetadataAndTokenURI(
         ddo,
@@ -200,7 +201,7 @@ export default function PublishPage({
       )
       if (!res?.transactionHash)
         throw new Error(
-          'Metadata could not be written into the NFT. Please hit Submit again to retry.'
+          'Metadata could not be written into the NFT. Please try again.'
         )
 
       LoggerInstance.log('[publish] setMetadata result', res)

--- a/src/components/Publish/index.tsx
+++ b/src/components/Publish/index.tsx
@@ -237,6 +237,7 @@ export default function PublishPage({
     let _datatokenAddress = datatokenAddress
     let _ddo = ddo
     let _ddoEncrypted = ddoEncrypted
+    let _did = did
 
     if (!_erc721Address || !_datatokenAddress) {
       const { erc721Address, datatokenAddress } = await create(values)
@@ -258,8 +259,9 @@ export default function PublishPage({
       setDdoEncrypted(ddoEncrypted)
     }
 
-    if (!did) {
+    if (!_did) {
       const { did } = await publish(values, _ddo, _ddoEncrypted)
+      _did = did
       setDid(did)
     }
   }


### PR DESCRIPTION
Quickest thing with most impact I could think of without much refactoring of that `handleSubmit`:

- split up `handleSubmit` into multiple methods
- collect everything we need to define success for each step in local state in addition to method-scoped variables
- when `handleSubmit` runs, only run each step if result is not yet present in local state
- when anything fails, _Submit_ button switches to _Retry_
- when anything fails, show error message encouraging users to hit _Retry_
- fixes #1509

user flows for testing:

- publish as before, verify all 3 steps can succeed
- reject first approve tx in wallet, verify all steps fail and publish stops
- hit Retry, verify all steps now succeed
- repeat for step 2 & step 3, somehow making them fail (like, running locally and sending bogus parameters, for step 1 & 3 rejecting in MetaMask works too), then hitting _Retry_ again and verify only relevant steps will run
- buy/download the final asset file, to make sure created tokens fit the created pricing and such