### PR TITLE
Add option to upload on publish

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "react-data-table-component": "^6.11.7",
         "react-dom": "^18.1.0",
         "react-dotdotdot": "^1.3.1",
+        "react-dropzone": "^14.2.1",
         "react-modal": "^3.15.1",
         "react-paginate": "^8.1.3",
         "react-spring": "^9.4.5",
@@ -17574,6 +17575,14 @@
         "node": ">= 4.5.0"
       }
     },
+    "node_modules/attr-accept": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/attr-accept/-/attr-accept-2.2.2.tgz",
+      "integrity": "sha512-7prDjvt9HmqiZ0cl5CRjtS84sEyhsHP2coDkaZKRKVfCDo9s7iw7ChVmar78Gu9pC4SoR/28wFu/G5JJhTnqEg==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/autoprefixer": {
       "version": "9.8.8",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.8.8.tgz",
@@ -24075,6 +24084,17 @@
       },
       "peerDependencies": {
         "webpack": "^4.0.0 || ^5.0.0"
+      }
+    },
+    "node_modules/file-selector": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/file-selector/-/file-selector-0.6.0.tgz",
+      "integrity": "sha512-QlZ5yJC0VxHxQQsQhXvBaC7VRJ2uaxTf+Tfpu4Z/OcVQJVpZO+DGU0rkoVW5ce2SccxugvpBJoMvUs59iILYdw==",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/file-system-cache": {
@@ -34759,6 +34779,22 @@
         "prop-types": "*",
         "react": "*",
         "react-dom": "*"
+      }
+    },
+    "node_modules/react-dropzone": {
+      "version": "14.2.1",
+      "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-14.2.1.tgz",
+      "integrity": "sha512-jzX6wDtAjlfwZ+Fbg+G17EszWUkQVxhMTWMfAC9qSUq7II2pKglHA8aarbFKl0mLpRPDaNUcy+HD/Sf4gkf76Q==",
+      "dependencies": {
+        "attr-accept": "^2.2.2",
+        "file-selector": "^0.6.0",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">= 10.13"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8 || 18.0.0"
       }
     },
     "node_modules/react-fast-compare": {
@@ -54939,6 +54975,11 @@
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
       "dev": true
     },
+    "attr-accept": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/attr-accept/-/attr-accept-2.2.2.tgz",
+      "integrity": "sha512-7prDjvt9HmqiZ0cl5CRjtS84sEyhsHP2coDkaZKRKVfCDo9s7iw7ChVmar78Gu9pC4SoR/28wFu/G5JJhTnqEg=="
+    },
     "autoprefixer": {
       "version": "9.8.8",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.8.8.tgz",
@@ -60137,6 +60178,14 @@
       "requires": {
         "loader-utils": "^2.0.0",
         "schema-utils": "^3.0.0"
+      }
+    },
+    "file-selector": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/file-selector/-/file-selector-0.6.0.tgz",
+      "integrity": "sha512-QlZ5yJC0VxHxQQsQhXvBaC7VRJ2uaxTf+Tfpu4Z/OcVQJVpZO+DGU0rkoVW5ce2SccxugvpBJoMvUs59iILYdw==",
+      "requires": {
+        "tslib": "^2.4.0"
       }
     },
     "file-system-cache": {
@@ -68468,6 +68517,16 @@
       "integrity": "sha512-ImqoKTD4ZdyfF/h7jdPCZur01QlZxx3A9/gZSf9mbvseNZwVTvd+dPwi/hg1UTtP+30luy2d5j0KG+XEfdBPLQ==",
       "requires": {
         "object.pick": "^1.3.0"
+      }
+    },
+    "react-dropzone": {
+      "version": "14.2.1",
+      "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-14.2.1.tgz",
+      "integrity": "sha512-jzX6wDtAjlfwZ+Fbg+G17EszWUkQVxhMTWMfAC9qSUq7II2pKglHA8aarbFKl0mLpRPDaNUcy+HD/Sf4gkf76Q==",
+      "requires": {
+        "attr-accept": "^2.2.2",
+        "file-selector": "^0.6.0",
+        "prop-types": "^15.8.1"
       }
     },
     "react-fast-compare": {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "react-data-table-component": "^6.11.7",
     "react-dom": "^18.1.0",
     "react-dotdotdot": "^1.3.1",
+    "react-dropzone": "^14.2.1",
     "react-modal": "^3.15.1",
     "react-paginate": "^8.1.3",
     "react-spring": "^9.4.5",

--- a/src/components/@shared/FormFields/FilesInput/DragAndDrop.tsx
+++ b/src/components/@shared/FormFields/FilesInput/DragAndDrop.tsx
@@ -1,0 +1,39 @@
+// Copyright Ocean Protocol contributors
+// SPDX-License-Identifier: Apache-2.0
+import React, { useCallback } from 'react'
+import { useDropzone } from 'react-dropzone'
+
+export default function DragAndDrop(props) {
+  const style = {
+    textAlign: 'center',
+    color: 'blue',
+    backgroundColor: 'white',
+    padding: '1.0em',
+    border: '1px dashed silver'
+  }
+
+  const onDrop = useCallback(
+    (acceptedFiles) => {
+      props.onFileDrop(acceptedFiles)
+    },
+    [props]
+  )
+
+  const { getRootProps, getInputProps, acceptedFiles } = useDropzone({
+    noClick: true,
+    maxFiles: 1,
+    onDrop
+  })
+  const files = acceptedFiles.map((file) => <p key={file.path}>{file.path}</p>)
+
+  return (
+    <div>
+      <section className="container">
+        <div style={style} {...getRootProps({ className: 'dropzone' })}>
+          <input {...getInputProps()} />
+          {files && files.length > 0 ? files : <p>Drop file here</p>}
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/components/@shared/FormFields/FilesInput/Info.tsx
+++ b/src/components/@shared/FormFields/FilesInput/Info.tsx
@@ -1,3 +1,5 @@
+// Copyright Ocean Protocol contributors
+// SPDX-License-Identifier: Apache-2.0
 import React, { ReactElement } from 'react'
 import { prettySize } from './utils'
 import cleanupContentType from '@utils/cleanupContentType'
@@ -19,7 +21,11 @@ export default function FileInfo({
     <div className={styles.info}>
       <h3 className={styles.url}>{file.url}</h3>
       <ul>
-        <li className={styles.success}>✓ URL confirmed</li>
+        {file.url?.length > 0 ? (
+          <li className={styles.success}>✓ URL confirmed</li>
+        ) : (
+          <li className={styles.success}>✓ Valid file</li>
+        )}
         {file.contentLength && <li>{prettySize(+file.contentLength)}</li>}
         {contentTypeCleaned && <li>{contentTypeCleaned}</li>}
       </ul>

--- a/src/components/Publish/Submission/Feedback.tsx
+++ b/src/components/Publish/Submission/Feedback.tsx
@@ -1,3 +1,5 @@
+// Copyright Ocean Protocol contributors
+// SPDX-License-Identifier: Apache-2.0
 import { useFormikContext } from 'formik'
 import React, { ReactElement } from 'react'
 import { FormPublishData } from '../_types'
@@ -7,26 +9,33 @@ import TransactionCount from './TransactionCount'
 export function Feedback(): ReactElement {
   const { values } = useFormikContext<FormPublishData>()
 
-  const items = Object.entries(values.feedback).map(([key, value], index) => (
-    <li key={index} className={styles[value.status]}>
-      <h3 className={styles.title}>{value.name}</h3>
-      <div className={styles.txs}>
-        {value.txCount > 0 && (
-          <TransactionCount
-            txCount={value.txCount}
-            chainId={values.user.chainId}
-            txHash={value.txHash}
-          />
+  const items = Object.entries(values.feedback)
+    .filter(([key, value]) =>
+      // Don't display "Upload File" section unless user is uploading a file
+      values.services[0].files[0].file || values.services[0].links[0].file
+        ? true
+        : key !== '0'
+    )
+    .map(([key, value], index) => (
+      <li key={index} className={styles[value.status]}>
+        <h3 className={styles.title}>{value.name}</h3>
+        <div className={styles.txs}>
+          {value.txCount > 0 && (
+            <TransactionCount
+              txCount={value.txCount}
+              chainId={values.user.chainId}
+              txHash={value.txHash}
+            />
+          )}
+        </div>
+        <p className={styles.description}>{value.description}</p>
+        {value.errorMessage && (
+          <span title={value.errorMessage} className={styles.errorMessage}>
+            {value.errorMessage}
+          </span>
         )}
-      </div>
-      <p className={styles.description}>{value.description}</p>
-      {value.errorMessage && (
-        <span title={value.errorMessage} className={styles.errorMessage}>
-          {value.errorMessage}
-        </span>
-      )}
-    </li>
-  ))
+      </li>
+    ))
 
   return <ol className={styles.feedback}>{items}</ol>
 }

--- a/src/components/Publish/_types.ts
+++ b/src/components/Publish/_types.ts
@@ -1,10 +1,13 @@
+// Copyright Ocean Protocol contributors
+// SPDX-License-Identifier: Apache-2.0
 import { ServiceComputeOptions } from '@oceanprotocol/lib'
 import { NftMetadata } from '@utils/nft'
 import { ReactElement } from 'react'
 import { PriceOptions } from 'src/@types/Price'
 
 interface FileMetadata {
-  url: string
+  url?: string
+  file?: File
   valid?: boolean
   contentLength?: string
   contentType?: string


### PR DESCRIPTION
This is the frontend part of the implementation for the spec described in #1483 (and #446).

Changes proposed in this PR:

- Add option (on Step 2 of Publish form) to upload file through drag and drop interface, instead of requiring user to provide file URL.
- Add additional feedback (on Step 5 of Publish form) for file uploads. This feedback only displays if the user is uploading a file.
- When uploading file on publish, user must pay fee charged by Provider.
- Use the initializeUpload/ and upload/ endpoints proposed in [PR #482 for Provider](https://github.com/oceanprotocol/provider/pull/482)