### PR TITLE
Correctly display trusted algorithms in compute asset

### DIFF
--- a/src/components/Asset/AssetActions/Compute/index.tsx
+++ b/src/components/Asset/AssetActions/Compute/index.tsx
@@ -271,7 +271,6 @@ export default function Compute({
 
   useEffect(() => {
     if (!asset) return
-
     getAlgorithmsForAsset(asset, newCancelToken()).then((algorithmsAssets) => {
       setDdoAlgorithmList(algorithmsAssets)
       getAlgorithmAssetSelectionList(asset, algorithmsAssets).then(

--- a/src/components/Publish/_constants.tsx
+++ b/src/components/Publish/_constants.tsx
@@ -41,8 +41,8 @@ export const wizardSteps: StepContent[] = [
 const computeOptions: ServiceComputeOptions = {
   allowRawAlgorithm: false,
   allowNetworkAccess: true,
-  publisherTrustedAlgorithmPublishers: null,
-  publisherTrustedAlgorithms: null
+  publisherTrustedAlgorithmPublishers: [],
+  publisherTrustedAlgorithms: []
 }
 
 export const initialValues: FormPublishData = {


### PR DESCRIPTION
Fixes #1538 
By default no algos are allowed now.
Also added filtering for trusted algo publishers. We can't add those in the market yet in edit, but they can be added from external sources.
Related to https://github.com/oceanprotocol/docs/pull/1032