### PR TITLE
ignore purgatory on getPublishedAssets (profile screen)

### DIFF
--- a/src/@utils/aquarius.ts
+++ b/src/@utils/aquarius.ts
@@ -321,6 +321,7 @@ export async function getPublishedAssets(
         }
       }
     },
+    ignorePurgatory: true,
     esPaginationOptions: {
       from: (Number(page) - 1 || 0) * 9,
       size: 9


### PR DESCRIPTION
- Fixes #1569 .

Changes proposed in this PR:

- ignore purgatory on getPublishedAssets method (profile screen)

Final result:

on Home & Search we filter by `purgatory.state: false`

![Screenshot 2022-07-07 at 08 34 36](https://user-images.githubusercontent.com/13741335/177774636-ba148c87-a30a-4dba-a584-67216f5cd196.png)

while Profile ignores this flag (`purgatory.state` is not send in query)

![Screenshot 2022-07-07 at 08 34 57](https://user-images.githubusercontent.com/13741335/177774661-abd1f886-0ed4-447b-ae17-1b92dd0a9dc8.png)
