### PR TITLE
mention legacy-peer-deps in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ cd market
 nvm use
 
 npm install
+# in case of dependency errors, rather use:
+# npm install --legacy-peer-deps
 npm start
 ```
 


### PR DESCRIPTION
Multiple reports about this, so add it to readme. 

The last remaining problematic dependency causing dependency installation errors is `use-dark-mode`, until this is replaced we need to mention `npm install --legacy-peer-deps`