### PR TITLE
catch nft state on asset detail

### DIFF
--- a/src/@context/Asset.tsx
+++ b/src/@context/Asset.tsx
@@ -100,7 +100,7 @@ function AssetProvider({
             break
           case 4:
             message =
-              'This asset has been disabled. If you just published this asset, please contact support.'
+              'This asset has been temporary disabled. If you just published this asset, please contact support.'
             break
         }
 

--- a/src/@context/Asset.tsx
+++ b/src/@context/Asset.tsx
@@ -100,7 +100,7 @@ function AssetProvider({
 
         setTitle(`This asset has been flagged as "${state}" by the publisher`)
         setIsV3Asset(await checkV3Asset(did, token))
-        setWarning(`\`${did}\`` + `\n\nPublisher Address: ${asset.nft.owner}`)
+        setError(`\`${did}\`` + `\n\nPublisher Address: ${asset.nft.owner}`)
         LoggerInstance.error(`[asset] Failed getting asset for ${did}`, asset)
         return
       }

--- a/src/@context/Asset.tsx
+++ b/src/@context/Asset.tsx
@@ -78,6 +78,13 @@ function AssetProvider({
             '\n\nWe could not find an asset for this DID in the cache. If you just published a new asset, wait some seconds and refresh this page.'
         )
         LoggerInstance.error(`[asset] Failed getting asset for ${did}`, asset)
+      } else if (asset.nft.state === 3) {
+        setIsV3Asset(await checkV3Asset(did, token))
+        setError(
+          `\`${did}\`` +
+            '\n\nThis asset has been reboked. If you just published a new asset, please contact support.'
+        )
+        LoggerInstance.error(`[asset] Failed getting asset for ${did}`, asset)
       } else {
         setError(undefined)
         setAsset((prevState) => ({

--- a/src/@context/Asset.tsx
+++ b/src/@context/Asset.tsx
@@ -25,6 +25,7 @@ export interface AssetProviderValue {
   title: string
   owner: string
   error?: string
+  warning?: string
   isAssetNetwork: boolean
   isV3Asset: boolean
   isOwner: boolean
@@ -52,6 +53,7 @@ function AssetProvider({
   const [owner, setOwner] = useState<string>()
   const [isOwner, setIsOwner] = useState<boolean>()
   const [error, setError] = useState<string>()
+  const [warning, setWarning] = useState<string>()
   const [loading, setLoading] = useState(false)
   const [isAssetNetwork, setIsAssetNetwork] = useState<boolean>()
   const [isV3Asset, setIsV3Asset] = useState<boolean>()
@@ -78,14 +80,37 @@ function AssetProvider({
             '\n\nWe could not find an asset for this DID in the cache. If you just published a new asset, wait some seconds and refresh this page.'
         )
         LoggerInstance.error(`[asset] Failed getting asset for ${did}`, asset)
-      } else if (asset.nft.state === 3) {
+        return
+      }
+
+      if (asset.nft.state) {
+        let message
+        switch (asset.nft.state) {
+          case 1:
+            message =
+              'This asset is in End-of-life. If you just published this asset, please contact support.'
+            break
+          case 2:
+            message =
+              'This asset has been deprecated. If you just published this asset, please contact support.'
+            break
+          case 3:
+            message =
+              'This asset has been revoked. If you just published this asset, please contact support.'
+            break
+          case 4:
+            message =
+              'This asset has been disabled. If you just published this asset, please contact support.'
+            break
+        }
+
         setIsV3Asset(await checkV3Asset(did, token))
-        setError(
-          `\`${did}\`` +
-            '\n\nThis asset has been reboked. If you just published a new asset, please contact support.'
-        )
+        setWarning(`\`${did}\`` + `\n\n${message}`)
         LoggerInstance.error(`[asset] Failed getting asset for ${did}`, asset)
-      } else {
+        return
+      }
+
+      if (asset) {
         setError(undefined)
         setAsset((prevState) => ({
           ...prevState,
@@ -185,6 +210,7 @@ function AssetProvider({
           title,
           owner,
           error,
+          warning,
           isInPurgatory,
           purgatoryData,
           loading,

--- a/src/@context/Asset.tsx
+++ b/src/@context/Asset.tsx
@@ -95,9 +95,6 @@ function AssetProvider({
           case 3:
             message = 'This asset has been revoked.'
             break
-          case 4:
-            message = 'This asset has been temporary disabled.'
-            break
         }
 
         setIsV3Asset(await checkV3Asset(did, token))

--- a/src/@context/Asset.tsx
+++ b/src/@context/Asset.tsx
@@ -84,21 +84,23 @@ function AssetProvider({
       }
 
       if (asset.nft.state) {
-        let message
+        // handle nft states as documented in https://docs.oceanprotocol.com/concepts/did-ddo/#state
+        let state
         switch (asset.nft.state) {
           case 1:
-            message = 'This asset is in End-of-life.'
+            state = 'end-of-life'
             break
           case 2:
-            message = 'This asset has been deprecated.'
+            state = 'deprecated'
             break
           case 3:
-            message = 'This asset has been revoked.'
+            state = 'revoked'
             break
         }
 
+        setTitle(`This asset has been flagged as "${state}" by the publisher`)
         setIsV3Asset(await checkV3Asset(did, token))
-        setWarning(`\`${did}\`` + `\n\n${message}`)
+        setWarning(`\`${did}\`` + `\n\nPublisher Address: ${asset.nft.owner}`)
         LoggerInstance.error(`[asset] Failed getting asset for ${did}`, asset)
         return
       }

--- a/src/@context/Asset.tsx
+++ b/src/@context/Asset.tsx
@@ -25,7 +25,6 @@ export interface AssetProviderValue {
   title: string
   owner: string
   error?: string
-  warning?: string
   isAssetNetwork: boolean
   isV3Asset: boolean
   isOwner: boolean

--- a/src/@context/Asset.tsx
+++ b/src/@context/Asset.tsx
@@ -53,7 +53,6 @@ function AssetProvider({
   const [owner, setOwner] = useState<string>()
   const [isOwner, setIsOwner] = useState<boolean>()
   const [error, setError] = useState<string>()
-  const [warning, setWarning] = useState<string>()
   const [loading, setLoading] = useState(false)
   const [isAssetNetwork, setIsAssetNetwork] = useState<boolean>()
   const [isV3Asset, setIsV3Asset] = useState<boolean>()
@@ -205,7 +204,6 @@ function AssetProvider({
           title,
           owner,
           error,
-          warning,
           isInPurgatory,
           purgatoryData,
           loading,

--- a/src/@context/Asset.tsx
+++ b/src/@context/Asset.tsx
@@ -87,20 +87,16 @@ function AssetProvider({
         let message
         switch (asset.nft.state) {
           case 1:
-            message =
-              'This asset is in End-of-life. If you just published this asset, please contact support.'
+            message = 'This asset is in End-of-life.'
             break
           case 2:
-            message =
-              'This asset has been deprecated. If you just published this asset, please contact support.'
+            message = 'This asset has been deprecated.'
             break
           case 3:
-            message =
-              'This asset has been revoked. If you just published this asset, please contact support.'
+            message = 'This asset has been revoked.'
             break
           case 4:
-            message =
-              'This asset has been temporary disabled. If you just published this asset, please contact support.'
+            message = 'This asset has been temporary disabled.'
             break
         }
 

--- a/src/components/Asset/AssetContent/index.tsx
+++ b/src/components/Asset/AssetContent/index.tsx
@@ -60,7 +60,7 @@ export default function AssetContent({
               <>
                 <Markdown
                   className={styles.description}
-                  text={asset?.metadata.description || ''}
+                  text={asset?.metadata?.description || ''}
                 />
                 <MetaSecondary ddo={asset} />
               </>

--- a/src/components/Asset/index.tsx
+++ b/src/components/Asset/index.tsx
@@ -18,7 +18,7 @@ export default function AssetDetails({ uri }: { uri: string }): ReactElement {
       router.push(`${v3MarketUri}${uri}`)
     }
     if (!asset || error || warning) {
-      setPageTitle('Could not retrieve asset')
+      setPageTitle(title || 'Could not retrieve asset')
       return
     }
     setPageTitle(isInPurgatory ? '' : title)

--- a/src/components/Asset/index.tsx
+++ b/src/components/Asset/index.tsx
@@ -9,23 +9,28 @@ import { v3MarketUri } from 'app.config'
 
 export default function AssetDetails({ uri }: { uri: string }): ReactElement {
   const router = useRouter()
-  const { asset, title, error, isInPurgatory, loading, isV3Asset } = useAsset()
+  const { asset, title, error, warning, isInPurgatory, loading, isV3Asset } =
+    useAsset()
   const [pageTitle, setPageTitle] = useState<string>()
 
   useEffect(() => {
     if (isV3Asset) {
       router.push(`${v3MarketUri}${uri}`)
     }
-    if (!asset || error) {
+    if (!asset || error || warning) {
       setPageTitle('Could not retrieve asset')
       return
     }
     setPageTitle(isInPurgatory ? '' : title)
-  }, [asset, error, isInPurgatory, isV3Asset, router, title, uri])
+  }, [asset, error, warning, isInPurgatory, isV3Asset, router, title, uri])
 
   return asset && pageTitle !== undefined && !loading ? (
     <Page title={pageTitle} uri={uri}>
       <AssetContent asset={asset} />
+    </Page>
+  ) : warning && isV3Asset === false ? (
+    <Page title={pageTitle} noPageHeader uri={uri}>
+      <Alert title={pageTitle} text={warning} state="warning" />
     </Page>
   ) : error && isV3Asset === false ? (
     <Page title={pageTitle} noPageHeader uri={uri}>

--- a/src/components/Asset/index.tsx
+++ b/src/components/Asset/index.tsx
@@ -28,13 +28,13 @@ export default function AssetDetails({ uri }: { uri: string }): ReactElement {
     <Page title={pageTitle} uri={uri}>
       <AssetContent asset={asset} />
     </Page>
-  ) : warning && isV3Asset === false ? (
+  ) : (warning || error) && isV3Asset === false ? (
     <Page title={pageTitle} noPageHeader uri={uri}>
-      <Alert title={pageTitle} text={warning} state="warning" />
-    </Page>
-  ) : error && isV3Asset === false ? (
-    <Page title={pageTitle} noPageHeader uri={uri}>
-      <Alert title={pageTitle} text={error} state="error" />
+      <Alert
+        title={pageTitle}
+        text={warning || error}
+        state={warning ? 'warning' : 'error'}
+      />
     </Page>
   ) : (
     <Page title={undefined} uri={uri}>

--- a/src/components/Asset/index.tsx
+++ b/src/components/Asset/index.tsx
@@ -9,32 +9,27 @@ import { v3MarketUri } from 'app.config'
 
 export default function AssetDetails({ uri }: { uri: string }): ReactElement {
   const router = useRouter()
-  const { asset, title, error, warning, isInPurgatory, loading, isV3Asset } =
-    useAsset()
+  const { asset, title, error, isInPurgatory, loading, isV3Asset } = useAsset()
   const [pageTitle, setPageTitle] = useState<string>()
 
   useEffect(() => {
     if (isV3Asset) {
       router.push(`${v3MarketUri}${uri}`)
     }
-    if (!asset || error || warning) {
+    if (!asset || error) {
       setPageTitle(title || 'Could not retrieve asset')
       return
     }
     setPageTitle(isInPurgatory ? '' : title)
-  }, [asset, error, warning, isInPurgatory, isV3Asset, router, title, uri])
+  }, [asset, error, isInPurgatory, isV3Asset, router, title, uri])
 
   return asset && pageTitle !== undefined && !loading ? (
     <Page title={pageTitle} uri={uri}>
       <AssetContent asset={asset} />
     </Page>
-  ) : (warning || error) && isV3Asset === false ? (
+  ) : error && isV3Asset === false ? (
     <Page title={pageTitle} noPageHeader uri={uri}>
-      <Alert
-        title={pageTitle}
-        text={warning || error}
-        state={warning ? 'warning' : 'error'}
-      />
+      <Alert title={pageTitle} text={error} state={'error'} />
     </Page>
   ) : (
     <Page title={undefined} uri={uri}>


### PR DESCRIPTION
- Fixes #1600 .

Changes proposed in this PR:

- added catch on nft state (solves app crashing)
- handled nft states

Result:

![Screenshot 2022-07-15 at 06 41 37](https://user-images.githubusercontent.com/13741335/180825938-47d4b879-22e1-44fa-912f-5f5e16324bf4.png)

Current states according to [docs](https://docs.oceanprotocol.com/concepts/did-ddo/#state)

0 | Active.
1 | End-of-life.
2 | Deprecated (by another asset).
3 | Revoked by publisher.
4 | Ordering is temporary disabled.

Messages: 

0: no message
1: 'This asset is in End-of-life.'
2. 'This asset has been deprecated.'
3: 'This asset has been revoked.'
4. no message