### PR TITLE
fix download

### DIFF
--- a/src/@utils/provider.ts
+++ b/src/@utils/provider.ts
@@ -115,7 +115,7 @@ export async function downloadFile(
   xhr.responseType = 'blob'
   xhr.open('GET', downloadUrl)
   xhr.onload = () => {
-    const fileName = downloadUrl.substr(downloadUrl.lastIndexOf('/'))
+    const fileName = 'placeholder'
     const blobURL = window.URL.createObjectURL(xhr.response)
     const a = document.createElement('a')
     a.href = blobURL

--- a/src/@utils/provider.ts
+++ b/src/@utils/provider.ts
@@ -110,5 +110,22 @@ export async function downloadFile(
     asset.services[0].serviceEndpoint,
     web3
   )
-  await downloadFileBrowser(downloadUrl)
+
+  const xhr = new XMLHttpRequest()
+  xhr.responseType = 'blob'
+  xhr.open('GET', downloadUrl)
+  xhr.onload = () => {
+    const fileName = downloadUrl.substr(downloadUrl.lastIndexOf('/'))
+    const blobURL = window.URL.createObjectURL(xhr.response)
+    const a = document.createElement('a')
+    a.href = blobURL
+    a.setAttribute('download', fileName)
+    document.body.appendChild(a)
+    a.click()
+    a.remove()
+    window.URL.revokeObjectURL(blobURL)
+  }
+  xhr.send(null)
+
+  // await downloadFileBrowser(downloadUrl)
 }


### PR DESCRIPTION
Will move this to ocean.js after testing. 

for this: did:op:2b9f0d0438eb603b30b4ac99a701f52d48a9b8d15e2254ea8b5e7f816f587987 it does nothing because it wants to redirect
for normal asset should just download.
Need to fix the name. 