### PR TITLE
Adding links to the docs on forking ocean market

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,6 +399,12 @@ Additionally, we would also advise that your retain the text saying "Powered by 
 
 Everything else is made open according to the apache2 license. We look forward to seeing your data marketplace!
 
+If you are looking to fork Ocean Market and create your own marketplace, you will find the following guides useful in our docs:
+
+- [Forking Ocean Market](https://docs.oceanprotocol.com/building-with-ocean/build-a-marketplace/forking-ocean-market)
+- [Customising your Market](https://docs.oceanprotocol.com/building-with-ocean/build-a-marketplace/customising-your-market)
+- [Deploying your Market](https://docs.oceanprotocol.com/building-with-ocean/build-a-marketplace/deploying-market)
+
 ## 💰 Pricing Options
 
 ### Fixed Pricing


### PR DESCRIPTION
Fixes #1637 

Changes proposed in this PR:

- Pointing people to the relevant section in the docs where they can find guides on forking, customising and deploying their own marketplace