### PR TITLE
changes to fields validation in Edit / Publish

### DIFF
--- a/src/components/@shared/FormInput/index.tsx
+++ b/src/components/@shared/FormInput/index.tsx
@@ -78,7 +78,8 @@ function checkError(
       form?.errors?.[parsedFieldName[0]]?.[parsedFieldName[1]]) ||
     (form?.touched[field.name] &&
       form?.errors[field.name] &&
-      field.name !== 'links')
+      field.name !== 'links' &&
+      field.name !== 'files')
   ) {
     return true
   }

--- a/src/components/Asset/Edit/_constants.ts
+++ b/src/components/Asset/Edit/_constants.ts
@@ -21,16 +21,23 @@ export const validationSchema = Yup.object().shape({
       Yup.object().shape({
         url: Yup.string()
           .min(1, `At least one file is required.`)
-          .max(
-            512,
-            (param) => `Links must be less than ${param.max} characters`
-          )
+          .max(512, (param) => `URL must be less than ${param.max} characters`)
           .url('Must be a valid URL.'),
         valid: Yup.boolean()
       })
     )
     .nullable(),
-  files: Yup.array<FileInfo[]>().nullable(),
+  files: Yup.array<FileInfo[]>()
+    .of(
+      Yup.object().shape({
+        url: Yup.string()
+          .min(1, `At least one file is required.`)
+          .max(512, (param) => `URL must be less than ${param.max} characters`)
+          .url('Must be a valid URL.'),
+        valid: Yup.boolean()
+      })
+    )
+    .nullable(),
   timeout: Yup.string().required('Required'),
   author: Yup.string()
     .max(256, (param) => `Author must have maximum ${param.max} characters`)

--- a/src/components/Asset/Edit/_constants.ts
+++ b/src/components/Asset/Edit/_constants.ts
@@ -6,13 +6,35 @@ import { ComputeEditForm, MetadataEditForm } from './_types'
 export const validationSchema = Yup.object().shape({
   name: Yup.string()
     .min(4, (param) => `Title must be at least ${param.min} characters`)
+    .max(512, (param) => `Title must be less than ${param.max} characters`)
     .required('Required'),
-  description: Yup.string().required('Required').min(10),
+  description: Yup.string()
+    .required('Required')
+    .min(10, (param) => `Description must be at least ${param.min} characters`)
+    .max(
+      7000,
+      (param) => `Description must be less than ${param.max} characters`
+    ),
   price: Yup.number().required('Required'),
-  links: Yup.array<any[]>().nullable(),
+  links: Yup.array<FileInfo[]>()
+    .of(
+      Yup.object().shape({
+        url: Yup.string()
+          .min(1, `At least one file is required.`)
+          .max(
+            512,
+            (param) => `Links must be less than ${param.max} characters`
+          )
+          .url('Must be a valid URL.'),
+        valid: Yup.boolean()
+      })
+    )
+    .nullable(),
   files: Yup.array<FileInfo[]>().nullable(),
   timeout: Yup.string().required('Required'),
-  author: Yup.string().nullable()
+  author: Yup.string()
+    .max(256, (param) => `Author must have maximum ${param.max} characters`)
+    .required('Required')
 })
 
 export function getInitialValues(
@@ -25,7 +47,7 @@ export function getInitialValues(
     description: metadata?.description,
     price,
     links: metadata?.links,
-    files: '',
+    files: [{ url: '', type: '' }],
     timeout: secondsToString(timeout),
     author: metadata?.author
   }

--- a/src/components/Asset/Edit/_types.ts
+++ b/src/components/Asset/Edit/_types.ts
@@ -1,10 +1,11 @@
+import { FileInfo } from '@oceanprotocol/lib'
 export interface MetadataEditForm {
   name: string
   description: string
   timeout: string
   price?: string
-  links?: string | any[]
-  files: string | any[]
+  links?: string[] | FileInfo[]
+  files: FileInfo[]
   author?: string
 }
 

--- a/src/components/Asset/Edit/_types.ts
+++ b/src/components/Asset/Edit/_types.ts
@@ -4,7 +4,7 @@ export interface MetadataEditForm {
   description: string
   timeout: string
   price?: string
-  links?: string[] | FileInfo[]
+  links?: string[] | any[]
   files: FileInfo[]
   author?: string
 }

--- a/src/components/Publish/_validation.ts
+++ b/src/components/Publish/_validation.ts
@@ -12,16 +12,21 @@ const validationMetadata = {
     .required('Required'),
   name: Yup.string()
     .min(4, (param) => `Title must be at least ${param.min} characters`)
+    .max(512, (param) => `Title must be less than ${param.max} characters`)
     .required('Required'),
   description: Yup.string()
     .min(10, (param) => `Description must be at least ${param.min} characters`)
     .max(
-      5000,
+      7000,
       (param) => `Description must have maximum ${param.max} characters`
     )
     .required('Required'),
-  author: Yup.string().required('Required'),
-  tags: Yup.string().nullable(),
+  author: Yup.string()
+    .max(256, (param) => `Author must have maximum ${param.max} characters`)
+    .required('Required'),
+  tags: Yup.string()
+    .max(256, (param) => `Tags must have maximum ${param.max} characters`)
+    .nullable(),
   termsAndConditions: Yup.boolean()
     .required('Required')
     .isTrue('Please agree to the Terms and Conditions.')

--- a/src/components/Publish/_validation.ts
+++ b/src/components/Publish/_validation.ts
@@ -36,7 +36,11 @@ const validationService = {
   files: Yup.array<{ url: string; valid: boolean }[]>()
     .of(
       Yup.object().shape({
-        url: Yup.string().url('Must be a valid URL.').required('Required'),
+        url: Yup.string()
+          .min(1, `At least one file is required.`)
+          .max(512, (param) => `URL must be less than ${param.max} characters`)
+          .url('Must be a valid URL.')
+          .required('Required'),
         valid: Yup.boolean().isTrue().required('File must be valid.')
       })
     )
@@ -45,7 +49,10 @@ const validationService = {
   links: Yup.array<{ url: string; valid: boolean }[]>()
     .of(
       Yup.object().shape({
-        url: Yup.string().url('Must be a valid URL.'),
+        url: Yup.string()
+          .min(1, `At least one file is required.`)
+          .max(512, (param) => `URL must be less than ${param.max} characters`)
+          .url('Must be a valid URL.'),
         // TODO: require valid file only when URL is given
         valid: Yup.boolean()
         // valid: Yup.boolean().isTrue('File must be valid.')


### PR DESCRIPTION
- Fixes #1244 .

Changes proposed in this PR:

- changes to Yup validation on edit form
- changes to Yup validation on publish form

Validation Based on [Schema](https://github.com/oceanprotocol/aquarius/pull/867)

WIP:

- [X] make sure edit and publish validation work the same way (~~right now there's a BUG on the Edit Form, it's not validating the Files field~~)
