### PR TITLE
Pass UrlFile object to Provider.checkFileUrl instead of string

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@coingecko/cryptoformat": "^0.5.4",
     "@loadable/component": "^5.15.2",
     "@oceanprotocol/art": "^3.2.0",
-    "@oceanprotocol/lib": "^2.2.3",
+    "@oceanprotocol/lib": "^2.3.0",
     "@oceanprotocol/typographies": "^0.1.0",
     "@oceanprotocol/use-dark-mode": "^2.4.3",
     "@tippyjs/react": "^4.2.6",

--- a/src/@utils/provider.ts
+++ b/src/@utils/provider.ts
@@ -83,7 +83,7 @@ export async function getFileDidInfo(
   }
 }
 
-export async function getFileUrlInfo(
+export async function getFileInfo(
   file: UrlFile,
   providerUrl: string
 ): Promise<FileInfo[]> {

--- a/src/@utils/provider.ts
+++ b/src/@utils/provider.ts
@@ -1,5 +1,4 @@
 import {
-  Arweave,
   ComputeAlgorithm,
   ComputeAsset,
   ComputeEnvironment,
@@ -85,7 +84,7 @@ export async function getFileDidInfo(
 }
 
 export async function getFileUrlInfo(
-  file: UrlFile | Arweave,
+  file: UrlFile,
   providerUrl: string
 ): Promise<FileInfo[]> {
   try {

--- a/src/@utils/provider.ts
+++ b/src/@utils/provider.ts
@@ -1,4 +1,5 @@
 import {
+  Arweave,
   ComputeAlgorithm,
   ComputeAsset,
   ComputeEnvironment,
@@ -6,7 +7,8 @@ import {
   FileInfo,
   LoggerInstance,
   ProviderComputeInitializeResults,
-  ProviderInstance
+  ProviderInstance,
+  UrlFile
 } from '@oceanprotocol/lib'
 import Web3 from 'web3'
 import { getValidUntilTime } from './compute'
@@ -83,11 +85,11 @@ export async function getFileDidInfo(
 }
 
 export async function getFileUrlInfo(
-  url: string,
+  file: UrlFile | Arweave,
   providerUrl: string
 ): Promise<FileInfo[]> {
   try {
-    const response = await ProviderInstance.checkFileUrl(url, providerUrl)
+    const response = await ProviderInstance.checkFileUrl(file, providerUrl)
     return response
   } catch (error) {
     LoggerInstance.error(error.message)

--- a/src/components/@shared/FormFields/FilesInput/index.tsx
+++ b/src/components/@shared/FormFields/FilesInput/index.tsx
@@ -3,7 +3,7 @@ import { useField, useFormikContext } from 'formik'
 import FileInfo from './Info'
 import UrlInput from '../URLInput'
 import { InputProps } from '@shared/FormInput'
-import { getFileUrlInfo } from '@utils/provider'
+import { getFileInfo } from '@utils/provider'
 import { FormPublishData } from 'src/components/Publish/_types'
 import { LoggerInstance, UrlFile } from '@oceanprotocol/lib'
 import { useAsset } from '@context/Asset'
@@ -28,7 +28,7 @@ export default function FilesInput(props: InputProps): ReactElement {
         url: url,
         method: 'GET'
       }
-      const checkedFile = await getFileUrlInfo(urlFile, providerUrl)
+      const checkedFile = await getFileInfo(urlFile, providerUrl)
 
       // error if something's not right from response
       if (!checkedFile)

--- a/src/components/@shared/FormFields/FilesInput/index.tsx
+++ b/src/components/@shared/FormFields/FilesInput/index.tsx
@@ -5,7 +5,7 @@ import UrlInput from '../URLInput'
 import { InputProps } from '@shared/FormInput'
 import { getFileUrlInfo } from '@utils/provider'
 import { FormPublishData } from 'src/components/Publish/_types'
-import { LoggerInstance } from '@oceanprotocol/lib'
+import { LoggerInstance, UrlFile } from '@oceanprotocol/lib'
 import { useAsset } from '@context/Asset'
 
 export default function FilesInput(props: InputProps): ReactElement {
@@ -23,7 +23,12 @@ export default function FilesInput(props: InputProps): ReactElement {
         ? values?.services[0].providerUrl.url
         : asset.services[0].serviceEndpoint
       setIsLoading(true)
-      const checkedFile = await getFileUrlInfo(url, providerUrl)
+      const urlFile: UrlFile = {
+        type: 'url',
+        url: url,
+        method: 'GET'
+      }
+      const checkedFile = await getFileUrlInfo(urlFile, providerUrl)
 
       // error if something's not right from response
       if (!checkedFile)

--- a/src/components/@shared/FormFields/FilesInput/index.tsx
+++ b/src/components/@shared/FormFields/FilesInput/index.tsx
@@ -23,11 +23,7 @@ export default function FilesInput(props: InputProps): ReactElement {
         ? values?.services[0].providerUrl.url
         : asset.services[0].serviceEndpoint
       setIsLoading(true)
-      const urlFile: UrlFile = {
-        type: 'url',
-        url: url,
-        method: 'GET'
-      }
+      const urlFile: UrlFile = { type: 'url', url, method: 'GET' }
       const checkedFile = await getFileInfo(urlFile, providerUrl)
 
       // error if something's not right from response

--- a/src/components/Asset/AssetActions/index.tsx
+++ b/src/components/Asset/AssetActions/index.tsx
@@ -7,7 +7,7 @@ import { compareAsBN } from '@utils/numbers'
 import { useAsset } from '@context/Asset'
 import { useWeb3 } from '@context/Web3'
 import Web3Feedback from '@shared/Web3Feedback'
-import { getFileDidInfo, getFileUrlInfo } from '@utils/provider'
+import { getFileDidInfo, getFileInfo } from '@utils/provider'
 import { getOceanConfig } from '@utils/ocean'
 import { useCancelToken } from '@hooks/useCancelToken'
 import { useIsMounted } from '@hooks/useIsMounted'
@@ -55,7 +55,7 @@ export default function AssetActions({
       try {
         const fileInfoResponse = formikState?.values?.services?.[0].files?.[0]
           .url
-          ? await getFileUrlInfo(
+          ? await getFileInfo(
               formikState?.values?.services?.[0].files?.[0].url,
               providerUrl
             )


### PR DESCRIPTION
Changes proposed in this PR:

- Pass `UrlFile` object to `Provider.checkFileUrl` instead of a string

Depends on https://github.com/oceanprotocol/ocean.js/pull/1627

Reasoning:

This is an incremental step towards supporting other file storage types like Arweave, Filecoin, etc...