### PR TITLE
Various veOCEAN features

### DIFF
--- a/content/site.json
+++ b/content/site.json
@@ -14,7 +14,7 @@
       "link": "/profile"
     }
   ],
-  "announcement": "Explore [OceanONDA V4](https://blog.oceanprotocol.com/how-to-publish-a-data-nft-f58ad2a622a9).",
+  "announcement": "[Lock your $OCEAN](https://df.oceandao.org/) to get veOCEAN, earn rewards and curate data.",
   "warning": {
     "ctd": "Compute-to-Data is still in a testing phase, please use it only on test networks."
   }

--- a/src/@types/aquarius/SearchQuery.ts
+++ b/src/@types/aquarius/SearchQuery.ts
@@ -7,7 +7,8 @@ export enum SortTermOptions {
   Created = 'nft.created',
   Relevance = '_score',
   Orders = 'stats.orders',
-  Allocated = 'stats.allocated'
+  Allocated = 'stats.allocated',
+  Price = 'stats.price.value'
 }
 
 // Note: could not figure out how to get `enum` to be ambiant

--- a/src/@utils/aquarius.ts
+++ b/src/@utils/aquarius.ts
@@ -215,6 +215,28 @@ export async function getAssetsFromDtList(
   }
 }
 
+export async function getAssetsFromNftList(
+  nftList: string[],
+  chainIds: number[],
+  cancelToken: CancelToken
+): Promise<Asset[]> {
+  try {
+    if (!(nftList.length > 0)) return
+
+    const baseParams = {
+      chainIds,
+      filters: [getFilterTerm('nftAddress', nftList)],
+      ignorePurgatory: true
+    } as BaseQueryParams
+    const query = generateBaseQuery(baseParams)
+
+    const queryResult = await queryMetadata(query, cancelToken)
+    return queryResult?.results
+  } catch (error) {
+    LoggerInstance.error(error.message)
+  }
+}
+
 export async function retrieveDDOListByDIDs(
   didList: string[],
   chainIds: number[],

--- a/src/@utils/veAllocation.ts
+++ b/src/@utils/veAllocation.ts
@@ -1,8 +1,19 @@
 import { AllLocked } from 'src/@types/subgraph/AllLocked'
+import { OwnAllocations } from 'src/@types/subgraph/OwnAllocations'
+import { NftOwnAllocation } from 'src/@types/subgraph/NftOwnAllocation'
+import { OceanLocked } from 'src/@types/subgraph/OceanLocked'
 import { gql, OperationResult } from 'urql'
 import { fetchData, getQueryContext } from './subgraph'
 import axios from 'axios'
-
+import networkdata from '../../content/networks-metadata.json'
+import {
+  getNetworkDataById,
+  getNetworkType,
+  NetworkType
+} from '@hooks/useNetworkMetadata'
+import { getAssetsFromNftList } from './aquarius'
+import { chainIdsSupported } from 'app.config'
+import { Asset } from '@oceanprotocol/lib'
 const AllLocked = gql`
   query AllLocked {
     veOCEANs(first: 1000) {
@@ -11,11 +22,84 @@ const AllLocked = gql`
   }
 `
 
-interface TotalVe {
+const OwnAllocations = gql`
+  query OwnAllocations($address: String) {
+    veAllocations(where: { allocationUser: $address }) {
+      id
+      nftAddress
+      allocated
+    }
+  }
+`
+const NftOwnAllocation = gql`
+  query NftOwnAllocation($address: String, $nftAddress: String) {
+    veAllocations(
+      where: { allocationUser: $address, nftAddress: $nftAddress }
+    ) {
+      allocated
+    }
+  }
+`
+const OceanLocked = gql`
+  query OceanLocked($address: String) {
+    veOCEAN(id: $address) {
+      id
+      lockedAmount
+      unlockTime
+    }
+  }
+`
+
+export interface TotalVe {
   totalLocked: number
   totalAllocated: number
 }
+export interface Allocation {
+  nftAddress: string
+  allocation: number
+}
+export interface AssetWithOwnAllocation {
+  did: string
+  nftAddress: string
+  allocation: number
+  name: string
+  symbol: string
+}
 
+export function getVeChainNetworkId(assetNetworkId: number): number {
+  const networkData = getNetworkDataById(networkdata, assetNetworkId)
+  const networkType = getNetworkType(networkData)
+  if (networkType === NetworkType.Mainnet) return 1
+  else return 5
+}
+
+export function getVeChainNetworkIds(assetNetworkIds: number[]): number[] {
+  const veNetworkIds: number[] = []
+  assetNetworkIds.forEach((x) => {
+    const id = getVeChainNetworkId(x)
+    veNetworkIds.indexOf(id) === -1 && veNetworkIds.push(id)
+  })
+  return veNetworkIds
+}
+export async function getNftOwnAllocation(
+  userAddress: string,
+  nftAddress: string,
+  networkId: number
+): Promise<number> {
+  const veNetworkId = getVeChainNetworkId(networkId)
+  const queryContext = getQueryContext(veNetworkId)
+  const fetchedAllocation: OperationResult<NftOwnAllocation, any> =
+    await fetchData(
+      NftOwnAllocation,
+      {
+        address: userAddress.toLowerCase(),
+        nftAddress: nftAddress.toLowerCase()
+      },
+      queryContext
+    )
+
+  return fetchedAllocation.data?.veAllocations[0]?.allocated
+}
 export async function getTotalAllocatedAndLocked(): Promise<TotalVe> {
   const totals = {
     totalLocked: 0,
@@ -42,4 +126,70 @@ export async function getTotalAllocatedAndLocked(): Promise<TotalVe> {
     0
   )
   return totals
+}
+
+export async function getLocked(
+  userAddress: string,
+  networkIds: number[]
+): Promise<number> {
+  let total = 0
+  const veNetworkIds = getVeChainNetworkIds(networkIds)
+  for (let i = 0; i < veNetworkIds.length; i++) {
+    const queryContext = getQueryContext(veNetworkIds[i])
+    const fetchedLocked: OperationResult<OceanLocked, any> = await fetchData(
+      OceanLocked,
+      {
+        address: userAddress.toLowerCase()
+      },
+      queryContext
+    )
+
+    fetchedLocked.data?.veOCEAN?.lockedAmount &&
+      (total += Number(fetchedLocked.data?.veOCEAN?.lockedAmount))
+    console.log('locked', fetchedLocked.data?.veOCEAN?.lockedAmount, total)
+  }
+
+  return total
+}
+
+export async function getOwnAllocations(
+  networkIds: number[],
+  userAddress: string
+): Promise<Allocation[]> {
+  const allocations: Allocation[] = []
+  const veNetworkIds = getVeChainNetworkIds(networkIds)
+  for (let i = 0; i < veNetworkIds.length; i++) {
+    const queryContext = getQueryContext(veNetworkIds[i])
+    const fetchedAllocations: OperationResult<OwnAllocations, any> =
+      await fetchData(
+        OwnAllocations,
+        {
+          address: userAddress.toLowerCase()
+        },
+        queryContext
+      )
+
+    fetchedAllocations.data?.veAllocations.forEach((x) =>
+      allocations.push({
+        nftAddress: x.nftAddress,
+        allocation: x.allocated / 100
+      })
+    )
+  }
+
+  return allocations
+}
+
+export async function getOwnAssetsWithAllocation(
+  networkIds: number[],
+  userAddress: string
+): Promise<Asset[]> {
+  const allocations = await getOwnAllocations(networkIds, userAddress)
+  const assets = await getAssetsFromNftList(
+    allocations.map((x) => x.nftAddress),
+    chainIdsSupported,
+    null
+  )
+
+  return assets
 }

--- a/src/components/Asset/AssetActions/AssetStats/index.tsx
+++ b/src/components/Asset/AssetActions/AssetStats/index.tsx
@@ -1,6 +1,8 @@
 import { useAsset } from '@context/Asset'
 import { useUserPreferences } from '@context/UserPreferences'
+import { useWeb3 } from '@context/Web3'
 import { formatPrice } from '@shared/Price/PriceUnit'
+import { getNftOwnAllocation } from '@utils/veAllocation'
 import React, { useEffect, useState } from 'react'
 import styles from './index.module.css'
 
@@ -9,7 +11,8 @@ export default function AssetStats() {
   const { asset } = useAsset()
   const [orders, setOrders] = useState(0)
   const [allocated, setAllocated] = useState(0)
-
+  const { accountId } = useWeb3()
+  const [ownAllocation, setOwnAllocation] = useState(0)
   useEffect(() => {
     if (!asset) return
 
@@ -18,6 +21,19 @@ export default function AssetStats() {
     setOrders(orders)
     setAllocated(allocated)
   }, [asset])
+
+  useEffect(() => {
+    async function init() {
+      const allocation = await getNftOwnAllocation(
+        accountId,
+        asset.nftAddress,
+        asset.chainId
+      )
+      console.log('allocation', allocation)
+      setOwnAllocation(allocation / 100)
+    }
+    init()
+  }, [accountId, asset.chainId, asset.nftAddress])
 
   return (
     <footer className={styles.stats}>
@@ -39,6 +55,11 @@ export default function AssetStats() {
           {orders === 1 ? '' : 's'}
         </span>
       )}
+      {ownAllocation && ownAllocation > 0 ? (
+        <span className={styles.stat}>
+          <span className={styles.number}>{ownAllocation}</span>% allocation
+        </span>
+      ) : null}
     </footer>
   )
 }

--- a/src/components/Home/index.tsx
+++ b/src/components/Home/index.tsx
@@ -1,20 +1,46 @@
 import React, { ReactElement, useEffect, useState } from 'react'
 import Button from '@shared/atoms/Button'
 import Bookmarks from './Bookmarks'
-import { generateBaseQuery } from '@utils/aquarius'
+import { generateBaseQuery, getFilterTerm } from '@utils/aquarius'
 import { useUserPreferences } from '@context/UserPreferences'
 import { SortTermOptions } from '../../@types/aquarius/SearchQuery'
 import TopSales from './TopSales'
 import TopTags from './TopTags'
 import SectionQueryResult from './SectionQueryResult'
 import styles from './index.module.css'
+import { useWeb3 } from '@context/Web3'
+import { getOwnAllocations } from '@utils/veAllocation'
 
 export default function HomePage(): ReactElement {
+  const { accountId } = useWeb3()
   const [queryLatest, setQueryLatest] = useState<SearchQuery>()
   const [queryMostSales, setQueryMostSales] = useState<SearchQuery>()
   const [queryMostAllocation, setQueryMostAllocation] = useState<SearchQuery>()
+  const [queryAssetsAllocation, setQueryAssetsAllocation] =
+    useState<SearchQuery>()
+  const [hasAllocations, setHasAllocations] = useState(false)
   const { chainIds } = useUserPreferences()
 
+  useEffect(() => {
+    async function init() {
+      if (!accountId) return
+      const allocations = await getOwnAllocations(chainIds, accountId)
+      setHasAllocations(allocations && allocations.length > 0)
+
+      const baseParams = {
+        chainIds,
+        filters: [
+          getFilterTerm(
+            'nftAddress',
+            allocations.map((x) => x.nftAddress)
+          )
+        ],
+        ignorePurgatory: true
+      } as BaseQueryParams
+      setQueryAssetsAllocation(generateBaseQuery(baseParams))
+    }
+    init()
+  }, [accountId, chainIds])
   useEffect(() => {
     const baseParams = {
       chainIds,
@@ -56,6 +82,12 @@ export default function HomePage(): ReactElement {
         <Bookmarks />
       </section>
 
+      {hasAllocations && (
+        <SectionQueryResult
+          title="Assets with allocations"
+          query={queryAssetsAllocation}
+        />
+      )}
       <SectionQueryResult
         title="Highest veOCEAN Allocations"
         query={queryMostAllocation}

--- a/src/components/Profile/Header/Stats.tsx
+++ b/src/components/Profile/Header/Stats.tsx
@@ -6,6 +6,8 @@ import NumberUnit from './NumberUnit'
 import styles from './Stats.module.css'
 import { useProfile } from '@context/Profile'
 import { getAccessDetailsForAssets } from '@utils/accessDetailsAndPricing'
+import { getLocked } from '@utils/veAllocation'
+import PriceUnit from '@shared/Price/PriceUnit'
 
 export default function Stats({
   accountId
@@ -16,7 +18,16 @@ export default function Stats({
   const { assets, assetsTotal, sales } = useProfile()
 
   const [totalSales, setTotalSales] = useState(0)
+  const [lockedOcean, setLockedOcean] = useState(0)
 
+  useEffect(() => {
+    async function getLockedOcean() {
+      if (!accountId) return
+      const locked = await getLocked(accountId, chainIds)
+      setLockedOcean(locked)
+    }
+    getLockedOcean()
+  }, [accountId, chainIds])
   useEffect(() => {
     if (!assets || !accountId || !chainIds) return
 
@@ -59,6 +70,20 @@ export default function Stats({
         value={sales < 0 ? 0 : sales}
       />
       <NumberUnit label="Published" value={assetsTotal} />
+      <NumberUnit
+        label="Locked OCEAN"
+        value={
+          lockedOcean > 0 ? (
+            <Conversion
+              price={lockedOcean}
+              symbol={'ocean'}
+              hideApproximateSymbol
+            />
+          ) : (
+            '0'
+          )
+        }
+      />
     </div>
   )
 }

--- a/src/components/Profile/Header/Stats.tsx
+++ b/src/components/Profile/Header/Stats.tsx
@@ -8,6 +8,7 @@ import { useProfile } from '@context/Profile'
 import { getAccessDetailsForAssets } from '@utils/accessDetailsAndPricing'
 import { getLocked } from '@utils/veAllocation'
 import PriceUnit from '@shared/Price/PriceUnit'
+import Tooltip from '@shared/atoms/Tooltip'
 
 export default function Stats({
   accountId
@@ -80,7 +81,10 @@ export default function Stats({
               hideApproximateSymbol
             />
           ) : (
-            '0'
+            <>
+              {'0'}
+              <Tooltip content="LOCK OCEAN!!" />
+            </>
           )
         }
       />

--- a/src/components/Search/sort.tsx
+++ b/src/components/Search/sort.tsx
@@ -13,7 +13,10 @@ const cx = classNames.bind(styles)
 
 const sortItems = [
   { display: 'Relevance', value: SortTermOptions.Relevance },
-  { display: 'Published', value: SortTermOptions.Created }
+  { display: 'Published', value: SortTermOptions.Created },
+  { display: 'Sales', value: SortTermOptions.Orders },
+  { display: 'Total allocation', value: SortTermOptions.Allocated },
+  { display: 'Price', value: SortTermOptions.Price }
 ]
 
 export default function Sort({


### PR DESCRIPTION
Closes #nothing
To test this go to https://test-df.oceandao.org/data (on goerli) lock ocean and then allocate. All the feature respect the network selection.

- Update top message to `[Lock your $OCEAN](https://df.oceandao.org/) to get veOCEAN, earn rewards and curate data.` 
- Added `Assets with allocations` in home page (if no allocations exist then that section is not displayed ) . This could have been in the profile page, but I intentionally added it on the homepage to increase the importance of df.
![image](https://user-images.githubusercontent.com/26000280/195813330-54cce7e8-1a05-4b65-9dd0-52f8ae2bab8e.png)

- Added locked ocean in profile
![image](https://user-images.githubusercontent.com/26000280/195813484-cb19c16b-8a5d-42d0-95ee-bebe2215b6fd.png)

- View own allocation on an asset (if available)
![image](https://user-images.githubusercontent.com/26000280/195813623-63d80c89-089f-46ca-bad5-f9ac87909e65.png)

- Added new sort options : `Sales`, `Price`, `Total Allocation`
![image](https://user-images.githubusercontent.com/26000280/195813952-52ffa8fd-730e-4964-8d83-fbdca07b13d2.png)


ToDo (@kremalicious  assistance required 😀 ) : 
- when you have no locked ocean i intentionally added a tooltip to "encourage" the user to go lock 😁 , but it looks .....
![image](https://user-images.githubusercontent.com/26000280/195814807-ede8da74-1e3e-4285-8234-4b54440e38ff.png)
- For locked ocean should we display also the actual ocean amount not just the conversion?
- the sort tab looks kinda off now
![image](https://user-images.githubusercontent.com/26000280/195815027-be6f4a28-73e8-477e-ab64-07fd40b794ad.png)
