### PR TITLE
Disable ordering when state is 4

### DIFF
--- a/src/@context/Asset.tsx
+++ b/src/@context/Asset.tsx
@@ -76,8 +76,7 @@ function AssetProvider({
         LoggerInstance.error(`[asset] Failed getting asset for ${did}`, asset)
         return
       }
-
-      if (asset.nft.state) {
+      if (asset.nft.state !== 0 && asset.nft.state !== 4) {
         // handle nft states as documented in https://docs.oceanprotocol.com/concepts/did-ddo/#state
         let state
         switch (asset.nft.state) {

--- a/src/components/Asset/AssetActions/Download.tsx
+++ b/src/components/Asset/AssetActions/Download.tsx
@@ -45,11 +45,15 @@ export default function Download({
   const [isPriceLoading, setIsPriceLoading] = useState(false)
   const [isOwned, setIsOwned] = useState(false)
   const [validOrderTx, setValidOrderTx] = useState('')
+  const [isTemporaryDisabled, setIsTemporaryDisabled] = useState(false)
   const [orderPriceAndFees, setOrderPriceAndFees] =
     useState<OrderPriceAndFees>()
 
   const isUnsupportedPricing = asset?.accessDetails?.type === 'NOT_SUPPORTED'
 
+  useEffect(() => {
+    Number(asset?.nft.state) === 4 && setIsTemporaryDisabled(true)
+  }, [asset?.nft.state])
   useEffect(() => {
     if (!asset?.accessDetails || isUnsupportedPricing) return
 
@@ -183,26 +187,36 @@ export default function Download({
   const AssetAction = ({ asset }: { asset: AssetExtended }) => {
     return (
       <div>
-        {isUnsupportedPricing ? (
+        {isTemporaryDisabled ? (
           <Alert
             className={styles.fieldWarning}
             state="info"
-            text={`No pricing schema available for this asset.`}
+            text={`The publisher temporary disabled ordering for this asset`}
           />
         ) : (
           <>
-            {isPriceLoading ? (
-              <Loader message="Calculating full price (including fees)" />
-            ) : (
-              <Price
-                accessDetails={asset.accessDetails}
-                orderPriceAndFees={orderPriceAndFees}
-                conversion
-                size="large"
+            {isUnsupportedPricing ? (
+              <Alert
+                className={styles.fieldWarning}
+                state="info"
+                text={`No pricing schema available for this asset.`}
               />
-            )}
+            ) : (
+              <>
+                {isPriceLoading ? (
+                  <Loader message="Calculating full price (including fees)" />
+                ) : (
+                  <Price
+                    accessDetails={asset.accessDetails}
+                    orderPriceAndFees={orderPriceAndFees}
+                    conversion
+                    size="large"
+                  />
+                )}
 
-            {!isInPurgatory && <PurchaseButton />}
+                {!isInPurgatory && <PurchaseButton />}
+              </>
+            )}
           </>
         )}
       </div>

--- a/src/components/Asset/AssetActions/Download.tsx
+++ b/src/components/Asset/AssetActions/Download.tsx
@@ -191,7 +191,7 @@ export default function Download({
           <Alert
             className={styles.fieldWarning}
             state="info"
-            text={`The publisher temporary disabled ordering for this asset`}
+            text={`The publisher temporarily disabled ordering for this asset`}
           />
         ) : (
           <>

--- a/src/components/Asset/AssetActions/Download.tsx
+++ b/src/components/Asset/AssetActions/Download.tsx
@@ -45,14 +45,14 @@ export default function Download({
   const [isPriceLoading, setIsPriceLoading] = useState(false)
   const [isOwned, setIsOwned] = useState(false)
   const [validOrderTx, setValidOrderTx] = useState('')
-  const [isTemporaryDisabled, setIsTemporaryDisabled] = useState(false)
+  const [isOrderDisabled, setIsOrderDisabled] = useState(false)
   const [orderPriceAndFees, setOrderPriceAndFees] =
     useState<OrderPriceAndFees>()
 
   const isUnsupportedPricing = asset?.accessDetails?.type === 'NOT_SUPPORTED'
 
   useEffect(() => {
-    Number(asset?.nft.state) === 4 && setIsTemporaryDisabled(true)
+    Number(asset?.nft.state) === 4 && setIsOrderDisabled(true)
   }, [asset?.nft.state])
   useEffect(() => {
     if (!asset?.accessDetails || isUnsupportedPricing) return
@@ -187,7 +187,7 @@ export default function Download({
   const AssetAction = ({ asset }: { asset: AssetExtended }) => {
     return (
       <div>
-        {isTemporaryDisabled ? (
+        {isOrderDisabled ? (
           <Alert
             className={styles.fieldWarning}
             state="info"


### PR DESCRIPTION
When the state of an nft is 4 ordering is imposible. Thest asset : did:op:6098e339b178d4d9273cd77e0f5d22394fef09fba3498f71abff5cabec306e37
![image](https://user-images.githubusercontent.com/26000280/196422697-32a07b96-f09c-4c95-a005-8750a7c600ba.png)
