### PR TITLE
ignore assets with state 5

### DIFF
--- a/src/@context/Asset.tsx
+++ b/src/@context/Asset.tsx
@@ -77,7 +77,7 @@ function AssetProvider({
         return
       }
 
-      if (asset.nft.state) {
+      if ([1, 2, 3].includes(asset.nft.state)) {
         // handle nft states as documented in https://docs.oceanprotocol.com/concepts/did-ddo/#state
         let state
         switch (asset.nft.state) {

--- a/src/@context/Profile/index.tsx
+++ b/src/@context/Profile/index.tsx
@@ -46,10 +46,12 @@ const clearedProfile: Profile = {
 function ProfileProvider({
   accountId,
   accountEns,
+  ownAccount,
   children
 }: {
   accountId: string
   accountEns: string
+  ownAccount: boolean
   children: ReactNode
 }): ReactElement {
   const { chainIds } = useUserPreferences()
@@ -111,7 +113,8 @@ function ProfileProvider({
         const result = await getPublishedAssets(
           accountId,
           chainIds,
-          cancelTokenSource.token
+          cancelTokenSource.token,
+          ownAccount
         )
         setAssets(result.results)
         setAssetsTotal(result.totalResults)
@@ -134,7 +137,13 @@ function ProfileProvider({
     return () => {
       cancelTokenSource.cancel()
     }
-  }, [accountId, appConfig.metadataCacheUri, chainIds, isEthAddress])
+  }, [
+    accountId,
+    appConfig.metadataCacheUri,
+    chainIds,
+    isEthAddress,
+    ownAccount
+  ])
 
   //
   // DOWNLOADS
@@ -158,7 +167,8 @@ function ProfileProvider({
         dtList,
         tokenOrders,
         chainIds,
-        cancelToken
+        cancelToken,
+        ownAccount
       )
       setDownloads(downloads)
       setDownloadsTotal(downloads.length)
@@ -167,7 +177,7 @@ function ProfileProvider({
         downloads
       )
     },
-    [accountId, chainIds]
+    [accountId, chainIds, ownAccount]
   )
 
   useEffect(() => {

--- a/src/@context/Profile/index.tsx
+++ b/src/@context/Profile/index.tsx
@@ -29,6 +29,7 @@ interface ProfileProviderValue {
   downloadsTotal: number
   isDownloadsLoading: boolean
   sales: number
+  ownAccount: boolean
 }
 
 const ProfileContext = createContext({} as ProfileProviderValue)
@@ -58,7 +59,6 @@ function ProfileProvider({
   const { appConfig } = useMarketMetadata()
 
   const [isEthAddress, setIsEthAddress] = useState<boolean>()
-
   //
   // Do nothing in all following effects
   // when accountId is no ETH address
@@ -163,6 +163,7 @@ function ProfileProvider({
       for (let i = 0; i < tokenOrders?.length; i++) {
         dtList.push(tokenOrders[i].datatoken.address)
       }
+
       const downloads = await getDownloadAssets(
         dtList,
         tokenOrders,
@@ -240,6 +241,7 @@ function ProfileProvider({
         downloads,
         downloadsTotal,
         isDownloadsLoading,
+        ownAccount,
         sales
       }}
     >

--- a/src/@types/aquarius/BaseQueryParams.d.ts
+++ b/src/@types/aquarius/BaseQueryParams.d.ts
@@ -12,4 +12,5 @@ interface BaseQueryParams {
   aggs?: any
   filters?: FilterTerm[]
   ignorePurgatory?: boolean
+  ignoreState?: boolean
 }

--- a/src/@utils/aquarius.ts
+++ b/src/@utils/aquarius.ts
@@ -319,6 +319,7 @@ export async function getPublishedAssets(
   accountId: string,
   chainIds: number[],
   cancelToken: CancelToken,
+  ignoreState = false,
   page?: number,
   type?: string,
   accesType?: string
@@ -347,7 +348,7 @@ export async function getPublishedAssets(
       }
     },
     ignorePurgatory: true,
-    ignoreState: true,
+    ignoreState,
     esPaginationOptions: {
       from: (Number(page) - 1 || 0) * 9,
       size: 9
@@ -461,7 +462,8 @@ export async function getDownloadAssets(
   dtList: string[],
   tokenOrders: OrdersData[],
   chainIds: number[],
-  cancelToken: CancelToken
+  cancelToken: CancelToken,
+  ignoreState = false
 ): Promise<DownloadedAsset[]> {
   const baseQueryparams = {
     chainIds,
@@ -470,7 +472,7 @@ export async function getDownloadAssets(
       getFilterTerm('services.type', 'access')
     ],
     ignorePurgatory: true,
-    ignoreState: true
+    ignoreState
   } as BaseQueryParams
   const query = generateBaseQuery(baseQueryparams)
   try {

--- a/src/@utils/aquarius.ts
+++ b/src/@utils/aquarius.ts
@@ -59,7 +59,22 @@ export function generateBaseQuery(
           getFilterTerm('_index', 'aquarius'),
           ...(baseQueryParams.ignorePurgatory
             ? []
-            : [getFilterTerm('purgatory.state', false)])
+            : [getFilterTerm('purgatory.state', false)]),
+          ...(baseQueryParams.ignoreState
+            ? []
+            : [
+                {
+                  bool: {
+                    must_not: [
+                      {
+                        term: {
+                          'nft.state': 5
+                        }
+                      }
+                    ]
+                  }
+                }
+              ])
         ]
       }
     }
@@ -332,6 +347,7 @@ export async function getPublishedAssets(
       }
     },
     ignorePurgatory: true,
+    ignoreState: true,
     esPaginationOptions: {
       from: (Number(page) - 1 || 0) * 9,
       size: 9
@@ -452,7 +468,9 @@ export async function getDownloadAssets(
     filters: [
       getFilterTerm('services.datatokenAddress', dtList),
       getFilterTerm('services.type', 'access')
-    ]
+    ],
+    ignorePurgatory: true,
+    ignoreState: true
   } as BaseQueryParams
   const query = generateBaseQuery(baseQueryparams)
   try {

--- a/src/components/Profile/History/PublishedList.tsx
+++ b/src/components/Profile/History/PublishedList.tsx
@@ -39,6 +39,7 @@ export default function PublishedList({
           accountId.toLowerCase(),
           chainIds,
           cancelToken,
+          false,
           page,
           service,
           access

--- a/src/components/Profile/History/PublishedList.tsx
+++ b/src/components/Profile/History/PublishedList.tsx
@@ -8,6 +8,7 @@ import { useCancelToken } from '@hooks/useCancelToken'
 import Filters from '../../Search/Filters'
 import { useMarketMetadata } from '@context/MarketMetadata'
 import { CancelToken } from 'axios'
+import { useProfile } from '@context/Profile'
 
 export default function PublishedList({
   accountId
@@ -16,7 +17,7 @@ export default function PublishedList({
 }): ReactElement {
   const { appConfig } = useMarketMetadata()
   const { chainIds } = useUserPreferences()
-
+  const { ownAccount } = useProfile()
   const [queryResult, setQueryResult] = useState<PagedAssets>()
   const [isLoading, setIsLoading] = useState(false)
   const [page, setPage] = useState<number>(1)
@@ -39,7 +40,7 @@ export default function PublishedList({
           accountId.toLowerCase(),
           chainIds,
           cancelToken,
-          false,
+          ownAccount,
           page,
           service,
           access
@@ -51,7 +52,7 @@ export default function PublishedList({
         setIsLoading(false)
       }
     },
-    []
+    [ownAccount]
   )
 
   useEffect(() => {

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -23,6 +23,7 @@ export default function PageProfile(): ReactElement {
       if (router.asPath === '/profile') {
         setFinalAccountEns(accountEns)
         setFinalAccountId(accountId)
+        setOwnAccount(true)
         return
       }
 
@@ -71,7 +72,7 @@ export default function PageProfile(): ReactElement {
       <ProfileProvider
         accountId={finalAccountId}
         accountEns={finalAccountEns}
-        ownAccount
+        ownAccount={ownAccount}
       >
         <ProfilePage accountId={finalAccountId} />
       </ProfileProvider>

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -13,7 +13,7 @@ export default function PageProfile(): ReactElement {
   const { accountId, accountEns } = useWeb3()
   const [finalAccountId, setFinalAccountId] = useState<string>()
   const [finalAccountEns, setFinalAccountEns] = useState<string>()
-
+  const [ownAccount, setOwnAccount] = useState(false)
   // Have accountId in path take over, if not present fall back to web3
   useEffect(() => {
     async function init() {
@@ -30,6 +30,7 @@ export default function PageProfile(): ReactElement {
 
       // Path has ETH address
       if (web3.utils.isAddress(pathAccount)) {
+        setOwnAccount(pathAccount === accountId)
         const finalAccountId = pathAccount || accountId
         setFinalAccountId(finalAccountId)
 
@@ -45,6 +46,7 @@ export default function PageProfile(): ReactElement {
           resolvedAccountId === '0x0000000000000000000000000000000000000000'
         )
           return
+        setOwnAccount(resolvedAccountId === accountId)
         setFinalAccountId(resolvedAccountId)
       }
     }
@@ -66,7 +68,11 @@ export default function PageProfile(): ReactElement {
       title={accountTruncate(finalAccountId)}
       noPageHeader
     >
-      <ProfileProvider accountId={finalAccountId} accountEns={finalAccountEns}>
+      <ProfileProvider
+        accountId={finalAccountId}
+        accountEns={finalAccountEns}
+        ownAccount
+      >
         <ProfilePage accountId={finalAccountId} />
       </ProfileProvider>
     </Page>


### PR DESCRIPTION
Closes #1747 

Assets with state 5 are ignored from all queries. 
They are shown in your own profile.

When viewing from another account: 
![image](https://user-images.githubusercontent.com/26000280/196677089-578c0f56-fd9c-4b95-90ed-7428a7b031ab.png)

My account:
![image](https://user-images.githubusercontent.com/26000280/196677134-c725699c-8776-4590-be1d-32936cb08d4f.png)
