### PR TITLE
Ensuring the market doesn't crash when asset has no services

### DIFF
--- a/src/@context/Asset.tsx
+++ b/src/@context/Asset.tsx
@@ -124,8 +124,8 @@ function AssetProvider({
 
     const accessDetails = await getAccessDetails(
       asset.chainId,
-      asset.services[0].datatokenAddress,
-      asset.services[0].timeout,
+      asset.services?.[0]?.datatokenAddress,
+      asset.services?.[0]?.timeout,
       accountId
     )
     setAsset((prevState) => ({

--- a/src/@context/Asset.tsx
+++ b/src/@context/Asset.tsx
@@ -120,12 +120,12 @@ function AssetProvider({
   // Helper: Get and set asset access details
   // -----------------------------------
   const fetchAccessDetails = useCallback(async (): Promise<void> => {
-    if (!asset?.chainId || !asset?.services) return
+    if (!asset?.chainId || !asset?.services?.length) return
 
     const accessDetails = await getAccessDetails(
       asset.chainId,
-      asset.services?.[0]?.datatokenAddress,
-      asset.services?.[0]?.timeout,
+      asset.services[0].datatokenAddress,
+      asset.services[0].timeout,
       accountId
     )
     setAsset((prevState) => ({

--- a/src/components/@shared/AssetTeaser/index.tsx
+++ b/src/components/@shared/AssetTeaser/index.tsx
@@ -58,7 +58,7 @@ export default function AssetTeaser({
               {removeMarkdown(description?.substring(0, 300) || '')}
             </Dotdotdot>
           </div>
-          {isUnsupportedPricing ? (
+          {isUnsupportedPricing || !asset.services.length ? (
             <strong>No pricing schema available</strong>
           ) : (
             <Price accessDetails={asset.accessDetails} size="small" />

--- a/src/components/@shared/FileIcon/index.tsx
+++ b/src/components/@shared/FileIcon/index.tsx
@@ -27,12 +27,13 @@ export default function FileIcon({
   const styleClasses = `${styles.file} ${small ? styles.small : ''} ${
     className || ''
   }`
-
+  console.log('isLoading', isLoading)
+  console.log('file', file)
   return (
     <ul className={styleClasses}>
-      {!isLoading && file ? (
+      {!isLoading ? (
         <>
-          {file.contentType || file.contentLength ? (
+          {file?.contentType || file?.contentLength ? (
             <>
               <li>{cleanupContentType(file.contentType)}</li>
               <li>

--- a/src/components/@shared/FileIcon/index.tsx
+++ b/src/components/@shared/FileIcon/index.tsx
@@ -27,8 +27,7 @@ export default function FileIcon({
   const styleClasses = `${styles.file} ${small ? styles.small : ''} ${
     className || ''
   }`
-  console.log('isLoading', isLoading)
-  console.log('file', file)
+
   return (
     <ul className={styleClasses}>
       {!isLoading ? (

--- a/src/components/Asset/AssetActions/Download.tsx
+++ b/src/components/Asset/AssetActions/Download.tsx
@@ -183,7 +183,6 @@ export default function Download({
       consumableFeedback={consumableFeedback}
     />
   )
-  console.log('asset.services', asset.services)
 
   const AssetAction = ({ asset }: { asset: AssetExtended }) => {
     return (

--- a/src/components/Asset/AssetActions/Download.tsx
+++ b/src/components/Asset/AssetActions/Download.tsx
@@ -183,6 +183,7 @@ export default function Download({
       consumableFeedback={consumableFeedback}
     />
   )
+  console.log('asset.services', asset.services)
 
   const AssetAction = ({ asset }: { asset: AssetExtended }) => {
     return (
@@ -195,7 +196,7 @@ export default function Download({
           />
         ) : (
           <>
-            {isUnsupportedPricing ? (
+            {isUnsupportedPricing || !asset.services.length ? (
               <Alert
                 className={styles.fieldWarning}
                 state="info"

--- a/src/components/Asset/AssetActions/Download.tsx
+++ b/src/components/Asset/AssetActions/Download.tsx
@@ -173,7 +173,7 @@ export default function Download({
       dtSymbol={asset?.datatokens[0]?.symbol}
       dtBalance={dtBalance}
       onClick={handleOrderOrDownload}
-      assetTimeout={secondsToString(asset.services[0].timeout)}
+      assetTimeout={secondsToString(asset?.services?.[0]?.timeout)}
       assetType={asset?.metadata?.type}
       stepText={statusText}
       isLoading={isLoading}

--- a/src/components/Asset/AssetContent/MetaMain/MetaAsset.tsx
+++ b/src/components/Asset/AssetContent/MetaMain/MetaAsset.tsx
@@ -30,8 +30,8 @@ export default function MetaAsset({
           networkId={asset?.chainId}
           path={
             isBlockscoutExplorer
-              ? `tokens/${asset?.services[0].datatokenAddress}`
-              : `token/${asset?.services[0].datatokenAddress}`
+              ? `tokens/${asset?.services?.[0]?.datatokenAddress}`
+              : `token/${asset?.services?.[0]?.datatokenAddress}`
           }
         >
           {`Accessed with ${dataTokenSymbol}`}


### PR DESCRIPTION
Fixes #1768

Changes proposed in this PR:

- Ensuring the market doesn't crash when asset has no services

**To test:** view [this asset](https://market-r84wawq01-oceanprotocol.vercel.app/asset/did:op:984ae0bc96d95d0ac766f82f7449d897adfec916e586078f0e2ee3db394cb5b2)