### PR TITLE
special veOCEAN number treatment

### DIFF
--- a/src/@utils/numbers.ts
+++ b/src/@utils/numbers.ts
@@ -1,4 +1,19 @@
+import { formatCurrency } from '@coingecko/cryptoformat'
 import { Decimal } from 'decimal.js'
+
+export function formatNumber(
+  price: number,
+  locale: string,
+  decimals?: string
+): string {
+  return formatCurrency(price, '', locale, false, {
+    // Not exactly clear what `significant figures` are for this library,
+    // but setting this seems to give us the formatting we want.
+    // See https://github.com/oceanprotocol/market/issues/70
+    significantFigures: 4,
+    ...(decimals && { decimalPlaces: Number(decimals) })
+  })
+}
 
 // Run decimal.js comparison
 // http://mikemcl.github.io/decimal.js/#cmp

--- a/src/@utils/veAllocation.ts
+++ b/src/@utils/veAllocation.ts
@@ -1,4 +1,4 @@
-import { AllLocked } from 'src/@types/subgraph/AllLocked'
+import { AllLockedQuery } from 'src/@types/subgraph/AllLockedQuery'
 import { OwnAllocations } from 'src/@types/subgraph/OwnAllocations'
 import { NftOwnAllocation } from 'src/@types/subgraph/NftOwnAllocation'
 import { OceanLocked } from 'src/@types/subgraph/OceanLocked'
@@ -16,7 +16,7 @@ import { chainIdsSupported } from '../../app.config'
 import { Asset } from '@oceanprotocol/lib'
 
 const AllLocked = gql`
-  query AllLocked {
+  query AllLockedQuery {
     veOCEANs(first: 1000) {
       lockedAmount
     }
@@ -115,7 +115,7 @@ export async function getTotalAllocatedAndLocked(): Promise<TotalVe> {
     0
   )
 
-  const fetchedLocked: OperationResult<AllLocked, any> = await fetchData(
+  const fetchedLocked: OperationResult<AllLockedQuery, any> = await fetchData(
     AllLocked,
     null,
     queryContext

--- a/src/@utils/veAllocation.ts
+++ b/src/@utils/veAllocation.ts
@@ -190,3 +190,9 @@ export async function getOwnAssetsWithAllocation(
 
   return assets
 }
+
+export function formatVeOcean(veocean: number, locale: string): string {
+  return new Intl.NumberFormat(locale, {
+    maximumFractionDigits: 0
+  }).format(veocean)
+}

--- a/src/@utils/veAllocation.ts
+++ b/src/@utils/veAllocation.ts
@@ -12,7 +12,7 @@ import {
   NetworkType
 } from '@hooks/useNetworkMetadata'
 import { getAssetsFromNftList } from './aquarius'
-import { chainIdsSupported } from 'app.config'
+import { chainIdsSupported } from '../../app.config'
 import { Asset } from '@oceanprotocol/lib'
 
 const AllLocked = gql`

--- a/src/@utils/veAllocation.ts
+++ b/src/@utils/veAllocation.ts
@@ -191,9 +191,3 @@ export async function getOwnAssetsWithAllocation(
 
   return assets
 }
-
-export function formatVeOcean(veocean: number, locale: string): string {
-  return new Intl.NumberFormat(locale, {
-    maximumFractionDigits: 0
-  }).format(veocean)
-}

--- a/src/@utils/veAllocation.ts
+++ b/src/@utils/veAllocation.ts
@@ -1,7 +1,7 @@
 import { AllLockedQuery } from 'src/@types/subgraph/AllLockedQuery'
-import { OwnAllocations } from 'src/@types/subgraph/OwnAllocations'
-import { NftOwnAllocation } from 'src/@types/subgraph/NftOwnAllocation'
-import { OceanLocked } from 'src/@types/subgraph/OceanLocked'
+import { OwnAllocationsQuery } from 'src/@types/subgraph/OwnAllocationsQuery'
+import { NftOwnAllocationQuery } from 'src/@types/subgraph/NftOwnAllocationQuery'
+import { OceanLockedQuery } from 'src/@types/subgraph/OceanLockedQuery'
 import { gql, OperationResult } from 'urql'
 import { fetchData, getQueryContext } from './subgraph'
 import axios from 'axios'
@@ -24,7 +24,7 @@ const AllLocked = gql`
 `
 
 const OwnAllocations = gql`
-  query OwnAllocations($address: String) {
+  query OwnAllocationsQuery($address: String) {
     veAllocations(where: { allocationUser: $address }) {
       id
       nftAddress
@@ -33,7 +33,7 @@ const OwnAllocations = gql`
   }
 `
 const NftOwnAllocation = gql`
-  query NftOwnAllocation($address: String, $nftAddress: String) {
+  query NftOwnAllocationQuery($address: String, $nftAddress: String) {
     veAllocations(
       where: { allocationUser: $address, nftAddress: $nftAddress }
     ) {
@@ -42,7 +42,7 @@ const NftOwnAllocation = gql`
   }
 `
 const OceanLocked = gql`
-  query OceanLocked($address: ID!) {
+  query OceanLockedQuery($address: ID!) {
     veOCEAN(id: $address) {
       id
       lockedAmount
@@ -87,7 +87,7 @@ export async function getNftOwnAllocation(
 ): Promise<number> {
   const veNetworkId = getVeChainNetworkId(networkId)
   const queryContext = getQueryContext(veNetworkId)
-  const fetchedAllocation: OperationResult<NftOwnAllocation, any> =
+  const fetchedAllocation: OperationResult<NftOwnAllocationQuery, any> =
     await fetchData(
       NftOwnAllocation,
       {
@@ -136,11 +136,12 @@ export async function getLocked(
   const veNetworkIds = getVeChainNetworkIds(networkIds)
   for (let i = 0; i < veNetworkIds.length; i++) {
     const queryContext = getQueryContext(veNetworkIds[i])
-    const fetchedLocked: OperationResult<OceanLocked, any> = await fetchData(
-      OceanLocked,
-      { address: userAddress.toLowerCase() },
-      queryContext
-    )
+    const fetchedLocked: OperationResult<OceanLockedQuery, any> =
+      await fetchData(
+        OceanLocked,
+        { address: userAddress.toLowerCase() },
+        queryContext
+      )
 
     fetchedLocked.data?.veOCEAN?.lockedAmount &&
       (total += Number(fetchedLocked.data?.veOCEAN?.lockedAmount))
@@ -157,7 +158,7 @@ export async function getOwnAllocations(
   const veNetworkIds = getVeChainNetworkIds(networkIds)
   for (let i = 0; i < veNetworkIds.length; i++) {
     const queryContext = getQueryContext(veNetworkIds[i])
-    const fetchedAllocations: OperationResult<OwnAllocations, any> =
+    const fetchedAllocations: OperationResult<OwnAllocationsQuery, any> =
       await fetchData(
         OwnAllocations,
         { address: userAddress.toLowerCase() },

--- a/src/components/@shared/AssetTeaser/index.module.css
+++ b/src/components/@shared/AssetTeaser/index.module.css
@@ -48,7 +48,7 @@
 }
 
 .footer {
-  margin-top: calc(var(--spacer) / 12);
+  margin-top: calc(var(--spacer) / 24);
 }
 
 .typeLabel {

--- a/src/components/@shared/AssetTeaser/index.tsx
+++ b/src/components/@shared/AssetTeaser/index.tsx
@@ -9,7 +9,7 @@ import NetworkName from '@shared/NetworkName'
 import styles from './index.module.css'
 import { getServiceByName } from '@utils/ddo'
 import { useUserPreferences } from '@context/UserPreferences'
-import { formatVeOcean } from '@utils/veAllocation'
+import { formatNumber } from '@utils/numbers'
 
 export declare type AssetTeaserProps = {
   asset: AssetExtended
@@ -81,7 +81,8 @@ export default function AssetTeaser({
                   ''
                 ) : (
                   <>
-                    <strong>{formatVeOcean(allocated, locale)}</strong> veOCEAN
+                    <strong>{formatNumber(allocated, locale, '0')}</strong>{' '}
+                    veOCEAN
                   </>
                 )}
               </span>

--- a/src/components/@shared/AssetTeaser/index.tsx
+++ b/src/components/@shared/AssetTeaser/index.tsx
@@ -8,8 +8,8 @@ import AssetType from '@shared/AssetType'
 import NetworkName from '@shared/NetworkName'
 import styles from './index.module.css'
 import { getServiceByName } from '@utils/ddo'
-import { formatPrice } from '@shared/Price/PriceUnit'
 import { useUserPreferences } from '@context/UserPreferences'
+import { formatVeOcean } from '@utils/veAllocation'
 
 export declare type AssetTeaserProps = {
   asset: AssetExtended
@@ -79,7 +79,7 @@ export default function AssetTeaser({
               <span className={styles.typeLabel}>
                 {allocated < 0
                   ? ''
-                  : `${formatPrice(allocated, locale)} veOCEAN`}
+                  : `${formatVeOcean(allocated, locale)} veOCEAN`}
               </span>
             ) : null}
             {orders && orders > 0 ? (

--- a/src/components/@shared/AssetTeaser/index.tsx
+++ b/src/components/@shared/AssetTeaser/index.tsx
@@ -77,23 +77,36 @@ export default function AssetTeaser({
           <footer className={styles.footer}>
             {allocated && allocated > 0 ? (
               <span className={styles.typeLabel}>
-                {allocated < 0
-                  ? ''
-                  : `${formatVeOcean(allocated, locale)} veOCEAN`}
+                {allocated < 0 ? (
+                  ''
+                ) : (
+                  <>
+                    <strong>{formatVeOcean(allocated, locale)}</strong> veOCEAN
+                  </>
+                )}
               </span>
             ) : null}
             {orders && orders > 0 ? (
               <span className={styles.typeLabel}>
-                {orders < 0
-                  ? 'N/A'
-                  : `${orders} ${orders === 1 ? 'sale' : 'sales'}`}
+                {orders < 0 ? (
+                  'N/A'
+                ) : (
+                  <>
+                    <strong>{orders}</strong> {orders === 1 ? 'sale' : 'sales'}
+                  </>
+                )}
               </span>
             ) : null}
             {asset.views && asset.views > 0 ? (
               <span className={styles.typeLabel}>
-                {asset.views < 0
-                  ? 'N/A'
-                  : `${asset.views} ${asset.views === 1 ? 'view' : 'views'}`}
+                {asset.views < 0 ? (
+                  'N/A'
+                ) : (
+                  <>
+                    <strong>{asset.views}</strong>{' '}
+                    {asset.views === 1 ? 'view' : 'views'}
+                  </>
+                )}
               </span>
             ) : null}
           </footer>

--- a/src/components/@shared/Price/PriceUnit.tsx
+++ b/src/components/@shared/Price/PriceUnit.tsx
@@ -1,17 +1,8 @@
 import React, { ReactElement } from 'react'
-import { formatCurrency } from '@coingecko/cryptoformat'
 import Conversion from './Conversion'
 import styles from './PriceUnit.module.css'
 import { useUserPreferences } from '@context/UserPreferences'
-
-export function formatPrice(price: number, locale: string): string {
-  return formatCurrency(price, '', locale, false, {
-    // Not exactly clear what `significant figures` are for this library,
-    // but setting this seems to give us the formatting we want.
-    // See https://github.com/oceanprotocol/market/issues/70
-    significantFigures: 4
-  })
-}
+import { formatNumber } from '@utils/numbers'
 
 export default function PriceUnit({
   price,
@@ -19,7 +10,8 @@ export default function PriceUnit({
   size = 'small',
   conversion,
   symbol,
-  type
+  type,
+  decimals
 }: {
   price: number
   type?: string
@@ -27,6 +19,7 @@ export default function PriceUnit({
   size?: 'small' | 'mini' | 'large'
   conversion?: boolean
   symbol?: string
+  decimals?: string
 }): ReactElement {
   const { locale } = useUserPreferences()
 
@@ -37,7 +30,7 @@ export default function PriceUnit({
       ) : (
         <>
           <div>
-            {Number.isNaN(price) ? '-' : formatPrice(price, locale)}{' '}
+            {Number.isNaN(price) ? '-' : formatNumber(price, locale, decimals)}{' '}
             <span className={styles.symbol}>{symbol}</span>
           </div>
           {conversion && <Conversion price={price} symbol={symbol} />}

--- a/src/components/Asset/AssetActions/AssetStats/index.tsx
+++ b/src/components/Asset/AssetActions/AssetStats/index.tsx
@@ -2,8 +2,7 @@ import { useAsset } from '@context/Asset'
 import { useUserPreferences } from '@context/UserPreferences'
 import { useWeb3 } from '@context/Web3'
 import Tooltip from '@shared/atoms/Tooltip'
-import { formatPrice } from '@shared/Price/PriceUnit'
-import { getNftOwnAllocation } from '@utils/veAllocation'
+import { formatVeOcean, getNftOwnAllocation } from '@utils/veAllocation'
 import React, { useEffect, useState } from 'react'
 import styles from './index.module.css'
 
@@ -33,8 +32,8 @@ export default function AssetStats() {
       {asset?.stats?.allocated && asset?.stats?.allocated > 0 ? (
         <span className={styles.stat}>
           <span className={styles.number}>
-            {formatPrice(asset.stats.allocated, locale)}
-          </span>
+            {formatVeOcean(asset.stats.allocated, locale)}
+          </span>{' '}
           veOCEAN
         </span>
       ) : null}

--- a/src/components/Asset/AssetActions/AssetStats/index.tsx
+++ b/src/components/Asset/AssetActions/AssetStats/index.tsx
@@ -2,7 +2,8 @@ import { useAsset } from '@context/Asset'
 import { useUserPreferences } from '@context/UserPreferences'
 import { useWeb3 } from '@context/Web3'
 import Tooltip from '@shared/atoms/Tooltip'
-import { formatVeOcean, getNftOwnAllocation } from '@utils/veAllocation'
+import { formatNumber } from '@utils/numbers'
+import { getNftOwnAllocation } from '@utils/veAllocation'
 import React, { useEffect, useState } from 'react'
 import styles from './index.module.css'
 
@@ -32,7 +33,7 @@ export default function AssetStats() {
       {asset?.stats?.allocated && asset?.stats?.allocated > 0 ? (
         <span className={styles.stat}>
           <span className={styles.number}>
-            {formatVeOcean(asset.stats.allocated, locale)}
+            {formatNumber(asset.stats.allocated, locale, '0')}
           </span>{' '}
           veOCEAN
         </span>

--- a/src/components/Footer/MarketStats/index.tsx
+++ b/src/components/Footer/MarketStats/index.tsx
@@ -124,8 +124,19 @@ export default function MarketStats(): ReactElement {
         />
       </div>
       <div>
-        <PriceUnit price={total.veLocked} symbol="OCEAN" size="small" /> locked.{' '}
-        <PriceUnit price={total.veAllocated} symbol="veOCEAN" size="small" />{' '}
+        <PriceUnit
+          decimals="0"
+          price={total.veLocked}
+          symbol="OCEAN"
+          size="small"
+        />{' '}
+        locked.{' '}
+        <PriceUnit
+          decimals="0"
+          price={total.veAllocated}
+          symbol="veOCEAN"
+          size="small"
+        />{' '}
         allocated.
       </div>
     </div>

--- a/src/components/Home/MostViews/index.test.tsx
+++ b/src/components/Home/MostViews/index.test.tsx
@@ -32,7 +32,7 @@ describe('components/Home/MostViews', () => {
     )
     queryMetadataMock.mockResolvedValue(queryMetadataBaseReturn)
     render(<MostViews />)
-    await screen.findByText('666 views')
+    await screen.findByText('666')
   })
 
   it('catches errors', async () => {


### PR DESCRIPTION
* fixes #1769

Use a tweaked `formatNumber()` method for formatting all occurances of veOCEAN number in the UI, and remove the digits for better readability. This still keeps the formatting consistent with all our other numbers. Both, `formatNumber()` and our `PriceUnit` component now accept optional `decimals` param/prop.

This is not doing any rounding, as we only use this number for presentation and not doing any chain events with it so this should be fine.

Before:

<img width="428" alt="Screenshot 2022-11-09 at 11 23 01" src="https://user-images.githubusercontent.com/90316/200817641-4914341e-167b-4a97-ab46-0526f52090fb.png">

After:

<img width="417" alt="Screenshot 2022-11-09 at 11 23 14" src="https://user-images.githubusercontent.com/90316/200817677-040248e2-1661-40e1-9f24-c00938d7d673.png">


And on asset teasers:

Before:

<img width="405" alt="Screenshot 2022-11-09 at 12 19 12" src="https://user-images.githubusercontent.com/90316/200828689-c58d2c84-aa03-4ca3-b24f-a8d6f44903fe.png">

After:

<img width="388" alt="Screenshot 2022-11-09 at 12 18 22" src="https://user-images.githubusercontent.com/90316/200828746-ca3c6c6a-8e4d-4a3b-b423-a3464d4267e8.png">

In footer:

After:

<img width="461" alt="Screenshot 2022-11-09 at 13 02 05" src="https://user-images.githubusercontent.com/90316/200837324-1203452b-c314-44b2-a603-5ac470242a75.png">


### Bonus

There were a lot of duplicate declarations in `@utils/veAllocation`, meaning some import name which then is declared again as a `const` with same name. That really needs to be avoided as this will lead to all sorts of unintended consequences, like broken builds. We never catched this cause `@utils/veAllocation` was never part of any test run. Earlier iteration of this PR was touching that file and this had to be fixed then
