### PR TITLE
filter out `className` from `Tippy`

### DIFF
--- a/src/components/@shared/atoms/Tooltip/index.tsx
+++ b/src/components/@shared/atoms/Tooltip/index.tsx
@@ -17,7 +17,8 @@ const DefaultTrigger = React.forwardRef((props, ref: any) => {
 })
 
 export default function Tooltip(props: TippyProps): ReactElement {
-  const { content, children, trigger, disabled, className, placement } = props
+  const { className, ...restProps } = props
+  const { content, children, trigger, disabled, placement } = props
   const [styles, api] = useSpring(() => animation.from)
 
   function onMount() {
@@ -60,7 +61,7 @@ export default function Tooltip(props: TippyProps): ReactElement {
       onMount={onMount}
       onHide={onHide}
       // animation
-      {...props}
+      {...restProps}
     >
       <div className={styleClasses}>{children || <DefaultTrigger />}</div>
     </Tippy>


### PR DESCRIPTION
* fixes #1692

Was a little annoyance as this warning was showing up sometimes also in test runs. So just filter out `className` as suggested in #1692, change should not affect any behavior