### PR TITLE
set S3 deploy script to Node.js v18

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
+        with:
+          node-version: 18
       - run: npm ci
 
       - run: npm run build:static


### PR DESCRIPTION
Missed one CI script in #1771, looks like the default Node.js version on GitHub is v16 when not specified. This is failing right now on `main`