### PR TITLE
default to static build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,7 @@ jobs:
           node-version: 18
       - run: npm ci
 
-      - run: npm run build:static
+      - run: npm run build
         env:
           NEXT_PUBLIC_INFURA_PROJECT_ID: ${{ secrets.NEXT_PUBLIC_INFURA_PROJECT_ID }}
 

--- a/README.md
+++ b/README.md
@@ -351,6 +351,8 @@ npm run build
 npm run serve
 ```
 
+The build command runs `next export` and outputs a static site under `./out`, ready to be deployed.
+
 ## ⬆️ Deployment
 
 Every branch or Pull Request is automatically deployed to multiple hosts for redundancy and emergency reasons:

--- a/package.json
+++ b/package.json
@@ -6,9 +6,8 @@
   "homepage": "https://market.oceanprotocol.com",
   "scripts": {
     "start": "npm run pregenerate && next dev -p 8000",
-    "build": "npm run pregenerate && next build",
-    "build:static": "npm run build && next export",
-    "serve": "serve -s public/",
+    "build": "npm run pregenerate && next build && next export",
+    "serve": "serve -s out/",
     "pregenerate": "bash scripts/pregenerate.sh",
     "test": "npm run pregenerate && npm run lint && npm run type-check && npm run jest",
     "jest": "jest -c .jest/jest.config.js",


### PR DESCRIPTION
Both Vercel & Netlify deploy market as a Node.js app. But we make sure to not use any Next.js server functionality to keep our deployments universal and not get vendor-locked-in.

Deploying as Node.js app led to problems on Netlify, where their [next-runtime](https://github.com/netlify/next-runtime) does way too many things for our use case, and one of them led to outage on Friday:

> The Next.js Runtime works by generating three Netlify functions that handle requests that haven't been pre-rendered. These are `___netlify-handler` (for SSR and API routes), `___netlify-odb-handler` (for ISR and fallback routes), and `_ipx` (for images)


The `___netlify-handler` edge function gets hit when e.g. asset page is accessed directly, and looks like these edge functions do not run Node.js v18, leading to error on Friday, which itself is a [bug in web3.js](https://github.com/web3/web3.js/issues/5601).

We do not have to deal with all that as all we need is a static site, so default all build commands to do just that.