### PR TITLE
fix file object on edit

### DIFF
--- a/src/components/Asset/Edit/EditMetadata.tsx
+++ b/src/components/Asset/Edit/EditMetadata.tsx
@@ -117,7 +117,11 @@ export default function Edit({
             {
               type: values.files[0].type,
               index: 0,
-              url: values.files[0].url,
+              [values.files[0].type === 'ipfs'
+                ? 'hash'
+                : values.files[0].type === 'arweave'
+                ? 'transactionId'
+                : 'url']: values.files[0].url,
               method: 'GET'
             }
           ]


### PR DESCRIPTION
- Fixes #1817 .

Changes proposed in this PR:

- fix edit file storage type


To test:

- upload a [file on arweave](https://hv4gxzchk24cqfezebn3ujjz6oy2kbtztv5vghn6kpbkjc3vg4rq.arweave.net/PXhr5EdWuCgUmSBbuiU587GlBnmde1MdvlPCpIt1NyM/) (I use this)
- publish that asset in the market
- go to the asset, the price should work and also consume 
- go to edit page of that asset
- change asset to another one in aweave (i might take some time to be indexed by ES) or just save
- in this PR everything should work and should be able to consume the new asset