### PR TITLE
Revert "default to static build (#1812)"

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,7 @@ jobs:
           node-version: 18
       - run: npm ci
 
-      - run: npm run build
+      - run: npm run build:static
         env:
           NEXT_PUBLIC_INFURA_PROJECT_ID: ${{ secrets.NEXT_PUBLIC_INFURA_PROJECT_ID }}
 

--- a/README.md
+++ b/README.md
@@ -351,8 +351,6 @@ npm run build
 npm run serve
 ```
 
-The build command runs `next export` and outputs a static site under `./out`, ready to be deployed.
-
 ## ⬆️ Deployment
 
 Every branch or Pull Request is automatically deployed to multiple hosts for redundancy and emergency reasons:

--- a/package.json
+++ b/package.json
@@ -6,8 +6,9 @@
   "homepage": "https://market.oceanprotocol.com",
   "scripts": {
     "start": "npm run pregenerate && next dev -p 8000",
-    "build": "npm run pregenerate && next build && next export",
-    "serve": "serve -s out/",
+    "build": "npm run pregenerate && next build",
+    "build:static": "npm run build && next export",
+    "serve": "serve -s public/",
     "pregenerate": "bash scripts/pregenerate.sh",
     "test": "npm run pregenerate && npm run lint && npm run type-check && npm run jest",
     "jest": "jest -c .jest/jest.config.js",


### PR DESCRIPTION
This reverts commit 28376404a8427e3aa5ac493bf5edde83bdc98960.

Much more complex because of how Next.js behaves with dynamic routing combined with static export so this needs more investigation, otherwise asset detail routes are broken again. For now, revert back to deliver Node.js app.