### PR TITLE
Updating readme instructions to include prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@
 
 The app is a React app built with [Next.js](https://nextjs.org) + TypeScript + CSS modules and will connect to Ocean remote components by default.
 
+Prerequisites:
+
+- [node.js](https://nodejs.org/en/) (required). Check the [.nvmrc](.nvmrc) file to make sure you are using the correct version of node.js.
+- [nvm](https://github.com/nvm-sh/nvm) (recommended). This is the recommend way to ensure you are using the correct version of node.js.
+- [git](https://git-scm.com/) is required to follow the instructions below.
+
 To start local development:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ The app is a React app built with [Next.js](https://nextjs.org) + TypeScript + C
 
 Prerequisites:
 
-- [node.js](https://nodejs.org/en/) (required). Check the [.nvmrc](.nvmrc) file to make sure you are using the correct version of node.js.
-- [nvm](https://github.com/nvm-sh/nvm) (recommended). This is the recommend way to ensure you are using the correct version of node.js.
-- [git](https://git-scm.com/) is required to follow the instructions below.
+- [Node.js](https://nodejs.org/en/) (required). Check the [.nvmrc](.nvmrc) file to make sure you are using the correct version of Node.js.
+- [nvm](https://github.com/nvm-sh/nvm) (recommended). This is the recommend way to manage Node.js versions.
+- [Git](https://git-scm.com/) is required to follow the instructions below.
 
 To start local development:
 


### PR DESCRIPTION
We've had at least a couple of people struggling with installation (#1823 and #1811) since we updated to using node.js 18 so I've updated the readme to include prerequisites.

Changes proposed in this PR:

- Updating readme instructions to include prerequisites