### PR TITLE
Fix filters

### DIFF
--- a/src/@types/aquarius/SearchQuery.ts
+++ b/src/@types/aquarius/SearchQuery.ts
@@ -46,6 +46,7 @@ declare global {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     query: any
     sort?: { [jsonPath: string]: SortDirectionOptions }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     aggs?: any
   }
 }

--- a/src/@utils/aquarius/index.test.ts
+++ b/src/@utils/aquarius/index.test.ts
@@ -9,8 +9,8 @@ const defaultBaseQueryReturn = {
   query: {
     bool: {
       filter: [
-        { terms: { chainId: [1, 3] } },
         { term: { _index: 'aquarius' } },
+        { terms: { chainId: [1, 3] } },
         { term: { 'purgatory.state': false } },
         { bool: { must_not: [{ term: { 'nft.state': 5 } }] } }
       ]

--- a/src/@utils/aquarius/index.ts
+++ b/src/@utils/aquarius/index.ts
@@ -44,6 +44,8 @@ export function generateBaseQuery(
 ): SearchQuery {
   const filters: unknown[] = [getFilterTerm('_index', 'aquarius')]
   baseQueryParams.filters && filters.push(...baseQueryParams.filters)
+  baseQueryParams.chainIds &&
+    filters.push(getFilterTerm('chainId', baseQueryParams.chainIds))
   !baseQueryParams.ignorePurgatory &&
     filters.push(getFilterTerm('purgatory.state', false))
   !baseQueryParams.ignoreState &&
@@ -58,7 +60,6 @@ export function generateBaseQuery(
         ]
       }
     })
-  console.log('filter', filters)
   const generatedQuery = {
     from: baseQueryParams.esPaginationOptions?.from || 0,
     size:
@@ -68,7 +69,7 @@ export function generateBaseQuery(
     query: {
       bool: {
         ...baseQueryParams.nestedQuery,
-        filter: [...filters]
+        filter: filters
       }
     }
   } as SearchQuery
@@ -83,7 +84,6 @@ export function generateBaseQuery(
         baseQueryParams.sortOptions.sortDirection ||
         SortDirectionOptions.Descending
     }
-
   return generatedQuery
 }
 

--- a/src/@utils/aquarius/index.ts
+++ b/src/@utils/aquarius/index.ts
@@ -42,6 +42,23 @@ export function getFilterTerm(
 export function generateBaseQuery(
   baseQueryParams: BaseQueryParams
 ): SearchQuery {
+  const filters: unknown[] = [getFilterTerm('_index', 'aquarius')]
+  baseQueryParams.filters && filters.push(...baseQueryParams.filters)
+  !baseQueryParams.ignorePurgatory &&
+    filters.push(getFilterTerm('purgatory.state', false))
+  !baseQueryParams.ignoreState &&
+    filters.push({
+      bool: {
+        must_not: [
+          {
+            term: {
+              'nft.state': 5
+            }
+          }
+        ]
+      }
+    })
+  console.log('filter', filters)
   const generatedQuery = {
     from: baseQueryParams.esPaginationOptions?.from || 0,
     size:
@@ -51,31 +68,7 @@ export function generateBaseQuery(
     query: {
       bool: {
         ...baseQueryParams.nestedQuery,
-        filter: [
-          ...(baseQueryParams.filters || []),
-          baseQueryParams.chainIds
-            ? getFilterTerm('chainId', baseQueryParams.chainIds)
-            : [],
-          getFilterTerm('_index', 'aquarius'),
-          ...(baseQueryParams.ignorePurgatory
-            ? []
-            : [getFilterTerm('purgatory.state', false)]),
-          ...(baseQueryParams.ignoreState
-            ? []
-            : [
-                {
-                  bool: {
-                    must_not: [
-                      {
-                        term: {
-                          'nft.state': 5
-                        }
-                      }
-                    ]
-                  }
-                }
-              ])
-        ]
+        filter: [...filters]
       }
     }
   } as SearchQuery


### PR DESCRIPTION
Empty arrays `[]` were added in the filters at some point. These will break when we update aquarius to the new version with es 8.5

This needs to be merged before aqua update on live @alexcos20 