### PR TITLE
fix 404 styling

### DIFF
--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -14,24 +14,8 @@ export default function Page404(): ReactElement {
     <>
       <Head>
         <style type="text/css">{`
-          body {
-            background: transparent url(${fishfail}) center bottom no-repeat !important;
-            background-size: cover !important;
-            min-height: 100vh;
-          }
-
           main {
             text-align: center;
-          }
-
-          header *,
-          footer *,
-          main * {
-            color: var(--brand-white) !important;
-          }
-
-          header svg path {
-            fill: var(--brand-white) !important;
           }
         `}</style>
       </Head>


### PR DESCRIPTION
- Fixes #1847 .

Changes proposed in this PR:

- fix light / dark mode in 404 page

on this PR:
<img width="1000" alt="Screenshot 2023-01-09 at 08 13 51" src="https://user-images.githubusercontent.com/13741335/211305619-0bca0ec5-c253-45bc-9e6f-39aaa94976f1.png">

<img width="1000" alt="Screenshot 2023-01-09 at 08 15 03" src="https://user-images.githubusercontent.com/13741335/211305823-d1a5e441-792e-4ebc-8943-402abc54e662.png">
