### PR TITLE
Throwing an error if the provider is not available

### DIFF
--- a/src/@utils/provider.ts
+++ b/src/@utils/provider.ts
@@ -147,3 +147,14 @@ export async function downloadFile(
   )
   await downloadFileBrowser(downloadUrl)
 }
+
+export async function checkValidProvider(
+  providerUrl: string
+): Promise<boolean> {
+  try {
+    const response = await ProviderInstance.isValidProvider(providerUrl)
+    return response
+  } catch (error) {
+    LoggerInstance.error(error.message)
+  }
+}

--- a/src/components/@shared/FormInput/InputElement/FilesInput/index.test.tsx
+++ b/src/components/@shared/FormInput/InputElement/FilesInput/index.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, render, screen } from '@testing-library/react'
 import React from 'react'
 import FilesInput from './index'
 import { useField } from 'formik'
-import { getFileInfo } from '@utils/provider'
+import { getFileInfo, checkValidProvider } from '@utils/provider'
 
 jest.mock('formik')
 jest.mock('@utils/provider')
@@ -48,6 +48,7 @@ const mockForm = {
 describe('@shared/FormInput/InputElement/FilesInput', () => {
   it('renders without crashing', async () => {
     ;(useField as jest.Mock).mockReturnValue([mockField, mockMeta, mockHelpers])
+    ;(checkValidProvider as jest.Mock).mockReturnValue(true)
     ;(getFileInfo as jest.Mock).mockReturnValue([
       {
         valid: true,

--- a/src/components/@shared/FormInput/InputElement/FilesInput/index.tsx
+++ b/src/components/@shared/FormInput/InputElement/FilesInput/index.tsx
@@ -4,7 +4,7 @@ import FileInfo from './Info'
 import UrlInput from '../URLInput'
 import { InputProps } from '@shared/FormInput'
 import { getFileInfo, checkValidProvider } from '@utils/provider'
-import { LoggerInstance, ProviderInstance } from '@oceanprotocol/lib'
+import { LoggerInstance } from '@oceanprotocol/lib'
 import { useAsset } from '@context/Asset'
 import { isGoogleUrl } from '@utils/url/index'
 
@@ -35,7 +35,6 @@ export default function FilesInput(props: InputProps): ReactElement {
 
       // Check if provider is a valid provider
       const isValid = await checkValidProvider(providerUrl)
-      console.log('\n\n\nisValid', isValid)
       if (!isValid)
         throw Error(
           '✗ Provider cannot be reached, please check status.oceanprotocol.com and try again later.'

--- a/src/components/@shared/FormInput/InputElement/FilesInput/index.tsx
+++ b/src/components/@shared/FormInput/InputElement/FilesInput/index.tsx
@@ -4,7 +4,7 @@ import FileInfo from './Info'
 import UrlInput from '../URLInput'
 import { InputProps } from '@shared/FormInput'
 import { getFileInfo } from '@utils/provider'
-import { LoggerInstance } from '@oceanprotocol/lib'
+import { LoggerInstance, ProviderInstance } from '@oceanprotocol/lib'
 import { useAsset } from '@context/Asset'
 import { isGoogleUrl } from '@utils/url/index'
 
@@ -32,6 +32,14 @@ export default function FilesInput(props: InputProps): ReactElement {
           'Google Drive is not a supported hosting service. Please use an alternative.'
         )
       }
+
+      // Check if provider is a valid provider
+      const isValid = await ProviderInstance.isValidProvider(providerUrl)
+
+      if (!isValid)
+        throw Error(
+          '✗ Provider cannot be reached, please check status.oceanprotocol.com and try again later.'
+        )
 
       const checkedFile = await getFileInfo(url, providerUrl, storageType)
 

--- a/src/components/@shared/FormInput/InputElement/FilesInput/index.tsx
+++ b/src/components/@shared/FormInput/InputElement/FilesInput/index.tsx
@@ -3,7 +3,7 @@ import { useField } from 'formik'
 import FileInfo from './Info'
 import UrlInput from '../URLInput'
 import { InputProps } from '@shared/FormInput'
-import { getFileInfo } from '@utils/provider'
+import { getFileInfo, checkValidProvider } from '@utils/provider'
 import { LoggerInstance, ProviderInstance } from '@oceanprotocol/lib'
 import { useAsset } from '@context/Asset'
 import { isGoogleUrl } from '@utils/url/index'
@@ -34,8 +34,8 @@ export default function FilesInput(props: InputProps): ReactElement {
       }
 
       // Check if provider is a valid provider
-      const isValid = await ProviderInstance.isValidProvider(providerUrl)
-
+      const isValid = await checkValidProvider(providerUrl)
+      console.log('\n\n\nisValid', isValid)
       if (!isValid)
         throw Error(
           '✗ Provider cannot be reached, please check status.oceanprotocol.com and try again later.'


### PR DESCRIPTION
Fixes #1513 

Changes proposed in this PR:

- Throwing an error if the provider cannot be reached when the user tries to validate a file.
- Previously the user would get the impression that there was an issue with their file, when actually the provider was down and not checking the file.  

**Note on testing:** you can't test this by inputting a custom provider in the publish form (that will generate an error when you click validate, and you won't get past that). I have been testing it locally and manually changed the default provider to get it to show that error when validating a file