### PR TITLE
Fix no pricing schema available in publish preview page

### DIFF
--- a/src/components/Publish/Preview/index.tsx
+++ b/src/components/Publish/Preview/index.tsx
@@ -37,7 +37,7 @@ export default function Preview(): ReactElement {
       asset.stats = {
         orders: null,
         price: {
-          value: values.pricing.price,
+          value: values.pricing.type === 'free' ? 0 : values.pricing.price,
           tokenSymbol: values.pricing?.baseToken?.symbol || 'OCEAN',
           tokenAddress: ZERO_ADDRESS
         }

--- a/src/components/Publish/Preview/index.tsx
+++ b/src/components/Publish/Preview/index.tsx
@@ -34,6 +34,14 @@ export default function Preview(): ReactElement {
         validOrderTx: '',
         publisherMarketOrderFee: '0'
       }
+      asset.stats = {
+        orders: null,
+        price: {
+          value: values.pricing.price,
+          tokenSymbol: values.pricing?.baseToken?.symbol || 'OCEAN',
+          tokenAddress: ZERO_ADDRESS
+        }
+      }
       setAsset(asset)
     }
     makeDdo()


### PR DESCRIPTION
Fixes #1902 .

Changes proposed in this PR:

- updated preview asset object stats with price for publish page