### PR TITLE
Bump connectkit to 1.3.0 and add support for walletconnect 2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@urql/exchange-refocus": "^1.0.0",
         "axios": "^1.2.0",
         "classnames": "^2.3.2",
-        "connectkit": "^1.2.3",
+        "connectkit": "^1.3.0",
         "date-fns": "^2.29.3",
         "decimal.js": "^10.4.2",
         "dom-confetti": "^0.2.2",
@@ -2398,6 +2398,7 @@
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.4.0.tgz",
       "integrity": "sha512-HLF2PnZAm1s4kGs30EiqKMgD7XsYaQ0XJnMR0rofEWQ5t5D60SfqpDIkIh1ze5tiEbyUWm8+VJ6W1/erVvBMIA==",
+      "peer": true,
       "dependencies": {
         "@codemirror/language": "^6.0.0",
         "@codemirror/state": "^6.0.0",
@@ -2448,6 +2449,7 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.1.0.tgz",
       "integrity": "sha512-mdvDQrjRmYPvQ3WrzF6Ewaao+NWERYtpthJvoQ3tK3t/44Ynhk8ZGjTSL9jMEv8CgSMogmt75X8ceOZRDSXHtQ==",
+      "peer": true,
       "dependencies": {
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.0.0",
@@ -2458,6 +2460,7 @@
       "version": "6.2.3",
       "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.2.3.tgz",
       "integrity": "sha512-V9n9233lopQhB1dyjsBK2Wc1i+8hcCqxl1wQ46c5HWWLePoe4FluV3TGHoZ04rBRlGjNyz9DTmpJErig8UE4jw==",
+      "peer": true,
       "dependencies": {
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.0.0",
@@ -2473,6 +2476,7 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/@codemirror/theme-one-dark/-/theme-one-dark-6.1.0.tgz",
       "integrity": "sha512-AiTHtFRu8+vWT9wWUWDM+cog6ZwgivJogB1Tm/g40NIpLwph7AnmxrSzWfvJN5fBVufsuwBxecQCNmdcR5D7Aw==",
+      "peer": true,
       "dependencies": {
         "@codemirror/language": "^6.0.0",
         "@codemirror/state": "^6.0.0",
@@ -25993,6 +25997,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-6.0.1.tgz",
       "integrity": "sha512-J8j+nZ+CdWmIeFIGXEFbFPtpiYacFMDR8GlHK3IyHQJMCaVRfGx9NT+Hxivv1ckLWPvNdZqndbr/7lVhrf/Svg==",
+      "peer": true,
       "dependencies": {
         "@codemirror/autocomplete": "^6.0.0",
         "@codemirror/commands": "^6.0.0",
@@ -26291,9 +26296,9 @@
       }
     },
     "node_modules/connectkit": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/connectkit/-/connectkit-1.2.3.tgz",
-      "integrity": "sha512-IZdfgbFMt0rPybJXmLSNDuvwFBF2Gh+9qjYxGN6EdWHPPKqXqdyOzrctQIHpr29JwqVT9jfsni2CNJPTSAjOsg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/connectkit/-/connectkit-1.3.0.tgz",
+      "integrity": "sha512-6EIETiGJjRWEwdRGUDjy+SWOqiCuRStKkib2xCQ8o2sOhKqSlDFC6W4B4L91J9EvrxoulRdlD80yPTYexbkUyA==",
       "dependencies": {
         "buffer": "^6.0.3",
         "detect-browser": "^5.3.0",
@@ -27086,7 +27091,8 @@
     "node_modules/crelt": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.5.tgz",
-      "integrity": "sha512-+BO9wPPi+DWTDcNYhr/W90myha8ptzftZT+LwcmUbbok0rcP/fequmFYCw8NMoH7pkAZQzU78b3kYrlua5a9eA=="
+      "integrity": "sha512-+BO9wPPi+DWTDcNYhr/W90myha8ptzftZT+LwcmUbbok0rcP/fequmFYCw8NMoH7pkAZQzU78b3kYrlua5a9eA==",
+      "peer": true
     },
     "node_modules/cross-blob": {
       "version": "3.0.2",
@@ -55725,12 +55731,8 @@
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.4.0.tgz",
       "integrity": "sha512-HLF2PnZAm1s4kGs30EiqKMgD7XsYaQ0XJnMR0rofEWQ5t5D60SfqpDIkIh1ze5tiEbyUWm8+VJ6W1/erVvBMIA==",
-      "requires": {
-        "@codemirror/language": "^6.0.0",
-        "@codemirror/state": "^6.0.0",
-        "@codemirror/view": "^6.6.0",
-        "@lezer/common": "^1.0.0"
-      }
+      "peer": true,
+      "requires": {}
     },
     "@codemirror/commands": {
       "version": "6.1.3",
@@ -55769,6 +55771,7 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.1.0.tgz",
       "integrity": "sha512-mdvDQrjRmYPvQ3WrzF6Ewaao+NWERYtpthJvoQ3tK3t/44Ynhk8ZGjTSL9jMEv8CgSMogmt75X8ceOZRDSXHtQ==",
+      "peer": true,
       "requires": {
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.0.0",
@@ -55779,6 +55782,7 @@
       "version": "6.2.3",
       "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.2.3.tgz",
       "integrity": "sha512-V9n9233lopQhB1dyjsBK2Wc1i+8hcCqxl1wQ46c5HWWLePoe4FluV3TGHoZ04rBRlGjNyz9DTmpJErig8UE4jw==",
+      "peer": true,
       "requires": {
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.0.0",
@@ -55794,6 +55798,7 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/@codemirror/theme-one-dark/-/theme-one-dark-6.1.0.tgz",
       "integrity": "sha512-AiTHtFRu8+vWT9wWUWDM+cog6ZwgivJogB1Tm/g40NIpLwph7AnmxrSzWfvJN5fBVufsuwBxecQCNmdcR5D7Aw==",
+      "peer": true,
       "requires": {
         "@codemirror/language": "^6.0.0",
         "@codemirror/state": "^6.0.0",
@@ -58519,7 +58524,6 @@
       "integrity": "sha512-rmVKYEsKzurfRU0xJz+iHelbi1LGlihIWZ7Qvmb/CBz1EkhL7nOkW4SVXmG2dA5Ce0si2gr88i6q4eBOMRNJ1w==",
       "dev": true,
       "requires": {
-        "@oclif/config": "^1.18.2",
         "@oclif/errors": "^1.3.5",
         "@oclif/help": "^1.0.1",
         "@oclif/parser": "^3.8.6",
@@ -69381,38 +69385,22 @@
       "version": "4.19.5",
       "resolved": "https://registry.npmjs.org/@uiw/codemirror-extensions-basic-setup/-/codemirror-extensions-basic-setup-4.19.5.tgz",
       "integrity": "sha512-1zt7ZPJ01xKkSW/KDy0FZNga0bngN1fC594wCVG7FBi60ehfcAucpooQ+JSPScKXopxcb+ugPKZvVLzr9/OfzA==",
-      "requires": {
-        "@codemirror/autocomplete": "^6.0.0",
-        "@codemirror/commands": "^6.0.0",
-        "@codemirror/language": "^6.0.0",
-        "@codemirror/lint": "^6.0.0",
-        "@codemirror/search": "^6.0.0",
-        "@codemirror/state": "^6.0.0",
-        "@codemirror/view": "^6.0.0"
-      }
+      "requires": {}
     },
     "@uiw/codemirror-themes": {
       "version": "4.19.5",
       "resolved": "https://registry.npmjs.org/@uiw/codemirror-themes/-/codemirror-themes-4.19.5.tgz",
       "integrity": "sha512-BWCTwQJaGiOc+nYqPLQDjmCtIojaCEKx2aO1bOTyGw0fisKwGw9Csll+bi9ujqA+vk6qYJmXI0P5K7kVs8fbdA==",
       "dev": true,
-      "requires": {
-        "@codemirror/language": "^6.0.0",
-        "@codemirror/state": "^6.0.0",
-        "@codemirror/view": "^6.0.0"
-      }
+      "requires": {}
     },
     "@uiw/react-codemirror": {
       "version": "4.19.5",
       "resolved": "https://registry.npmjs.org/@uiw/react-codemirror/-/react-codemirror-4.19.5.tgz",
       "integrity": "sha512-ZCHh8d7beXbF8/t7F1+yHht6A9Y6CdKeOkZq4A09lxJEnyTQrj1FMf2zvfaqc7K23KNjkTCtSlbqKKbVDgrWaw==",
       "requires": {
-        "@babel/runtime": "^7.18.6",
         "@codemirror/commands": "^6.1.0",
-        "@codemirror/state": "^6.1.1",
-        "@codemirror/theme-one-dark": "^6.0.0",
-        "@uiw/codemirror-extensions-basic-setup": "4.19.5",
-        "codemirror": "^6.0.0"
+        "@uiw/codemirror-extensions-basic-setup": "4.19.5"
       }
     },
     "@urql/core": {
@@ -71405,7 +71393,7 @@
         "git-url-parse": "11.6.0",
         "glob": "8.0.1",
         "global-agent": "3.0.0",
-        "graphql": "15.8.0",
+        "graphql": "14.0.2 - 14.2.0 || ^14.3.1 || ^15.0.0",
         "graphql-tag": "2.12.6",
         "listr": "0.14.3",
         "lodash.identity": "3.0.0",
@@ -71646,7 +71634,7 @@
         "cosmiconfig": "^7.0.1",
         "dotenv": "^16.0.0",
         "glob": "^8.0.0",
-        "graphql": "15.8.0",
+        "graphql": "14.0.2 - 14.2.0 || ^14.3.1 || ^15.0.0",
         "graphql-tag": "^2.10.1",
         "lodash.debounce": "^4.0.8",
         "lodash.merge": "^4.6.1",
@@ -74190,6 +74178,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-6.0.1.tgz",
       "integrity": "sha512-J8j+nZ+CdWmIeFIGXEFbFPtpiYacFMDR8GlHK3IyHQJMCaVRfGx9NT+Hxivv1ckLWPvNdZqndbr/7lVhrf/Svg==",
+      "peer": true,
       "requires": {
         "@codemirror/autocomplete": "^6.0.0",
         "@codemirror/commands": "^6.0.0",
@@ -74444,9 +74433,9 @@
       }
     },
     "connectkit": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/connectkit/-/connectkit-1.2.3.tgz",
-      "integrity": "sha512-IZdfgbFMt0rPybJXmLSNDuvwFBF2Gh+9qjYxGN6EdWHPPKqXqdyOzrctQIHpr29JwqVT9jfsni2CNJPTSAjOsg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/connectkit/-/connectkit-1.3.0.tgz",
+      "integrity": "sha512-6EIETiGJjRWEwdRGUDjy+SWOqiCuRStKkib2xCQ8o2sOhKqSlDFC6W4B4L91J9EvrxoulRdlD80yPTYexbkUyA==",
       "requires": {
         "buffer": "^6.0.3",
         "detect-browser": "^5.3.0",
@@ -75071,7 +75060,8 @@
     "crelt": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.5.tgz",
-      "integrity": "sha512-+BO9wPPi+DWTDcNYhr/W90myha8ptzftZT+LwcmUbbok0rcP/fequmFYCw8NMoH7pkAZQzU78b3kYrlua5a9eA=="
+      "integrity": "sha512-+BO9wPPi+DWTDcNYhr/W90myha8ptzftZT+LwcmUbbok0rcP/fequmFYCw8NMoH7pkAZQzU78b3kYrlua5a9eA==",
+      "peer": true
     },
     "cross-blob": {
       "version": "3.0.2",
@@ -84577,7 +84567,6 @@
       "integrity": "sha512-AoD7v132iYDV4K78yN2OLgTPwtAKn0XlD2pOhzyBxiI8PeXzozhbKyPV7zUOJUPETj+pcEVfuYj5ZN/8+bhbCw==",
       "peer": true,
       "requires": {
-        "@babel/core": "^7.20.0",
         "@babel/plugin-proposal-async-generator-functions": "^7.0.0",
         "@babel/plugin-proposal-class-properties": "^7.0.0",
         "@babel/plugin-proposal-export-default-from": "^7.0.0",
@@ -84631,7 +84620,6 @@
       "integrity": "sha512-DSdrEHuQ22ixY7DyipyKkIcqhOJrt5s6h6X7BYJCP9AMUfXOwLe2biY3BcgJz5GOXv8/Akry4vTCvQscVS1otQ==",
       "peer": true,
       "requires": {
-        "@babel/core": "^7.20.0",
         "babel-preset-fbjs": "^3.4.0",
         "hermes-parser": "0.8.0",
         "metro-babel-transformer": "0.73.9",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@urql/exchange-refocus": "^1.0.0",
     "axios": "^1.2.0",
     "classnames": "^2.3.2",
-    "connectkit": "^1.2.3",
+    "connectkit": "^1.3.0",
     "date-fns": "^2.29.3",
     "decimal.js": "^10.4.2",
     "dom-confetti": "^0.2.2",

--- a/src/@utils/wallet/index.ts
+++ b/src/@utils/wallet/index.ts
@@ -30,7 +30,8 @@ export const wagmiClient = createClient(
     appName: 'Ocean Market',
     infuraId: process.env.NEXT_PUBLIC_INFURA_PROJECT_ID,
     // TODO: mapping between appConfig.chainIdsSupported and wagmi chainId
-    chains: [mainnet, polygon, goerli, polygonMumbai]
+    chains: [mainnet, polygon, goerli, polygonMumbai],
+    walletConnectProjectId: process.env.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID
   })
 )
 


### PR DESCRIPTION
Fixes # .

Changes proposed in this PR:

- bump connectkit@1.3.0 [walletconnect v2 support anouncement](https://docs.family.co/connectkit/migration-guide#section-130-breaking-changes)
- add required project id
