### PR TITLE
bump ocean.js lib to fix nonce issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@coingecko/cryptoformat": "^0.5.4",
         "@loadable/component": "^5.15.2",
         "@oceanprotocol/art": "^3.2.0",
-        "@oceanprotocol/lib": "^3.0.2",
+        "@oceanprotocol/lib": "^3.0.3",
         "@oceanprotocol/typographies": "^0.1.0",
         "@oceanprotocol/use-dark-mode": "^2.4.3",
         "@orbisclub/orbis-sdk": "^0.4.40",
@@ -6081,9 +6081,9 @@
       "integrity": "sha512-PJih7C6LHaWHHj1qgxZsSkEqKphhJrL3G7WuMOxl4N1daDrF6sooDDU+9dZkcHSVPc7cMjkFqLc5fP58NSAobw=="
     },
     "node_modules/@oceanprotocol/lib": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@oceanprotocol/lib/-/lib-3.0.2.tgz",
-      "integrity": "sha512-yp75eYcFzqqgUAzG+fkLXHrNaA/ZZvogEE25NOy2DI5EAUp1Wm6tZ0q6AIH0i05KCPOfXoIGwqTBlfQa0rh48A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@oceanprotocol/lib/-/lib-3.0.3.tgz",
+      "integrity": "sha512-e4O3C5+Gw16FPkXJyE4cgspSnc7615lKg3VDiSarG10HDBt9WVmniyI9i03wYFwjz4R7op8O8EtF9OQnXWfd6g==",
       "dependencies": {
         "@oceanprotocol/contracts": "^1.1.14",
         "cross-fetch": "^3.1.5",
@@ -58451,9 +58451,9 @@
       "integrity": "sha512-PJih7C6LHaWHHj1qgxZsSkEqKphhJrL3G7WuMOxl4N1daDrF6sooDDU+9dZkcHSVPc7cMjkFqLc5fP58NSAobw=="
     },
     "@oceanprotocol/lib": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@oceanprotocol/lib/-/lib-3.0.2.tgz",
-      "integrity": "sha512-yp75eYcFzqqgUAzG+fkLXHrNaA/ZZvogEE25NOy2DI5EAUp1Wm6tZ0q6AIH0i05KCPOfXoIGwqTBlfQa0rh48A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@oceanprotocol/lib/-/lib-3.0.3.tgz",
+      "integrity": "sha512-e4O3C5+Gw16FPkXJyE4cgspSnc7615lKg3VDiSarG10HDBt9WVmniyI9i03wYFwjz4R7op8O8EtF9OQnXWfd6g==",
       "requires": {
         "@oceanprotocol/contracts": "^1.1.14",
         "cross-fetch": "^3.1.5",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@coingecko/cryptoformat": "^0.5.4",
     "@loadable/component": "^5.15.2",
     "@oceanprotocol/art": "^3.2.0",
-    "@oceanprotocol/lib": "^3.0.2",
+    "@oceanprotocol/lib": "^3.0.3",
     "@oceanprotocol/typographies": "^0.1.0",
     "@oceanprotocol/use-dark-mode": "^2.4.3",
     "@orbisclub/orbis-sdk": "^0.4.40",


### PR DESCRIPTION
Fixes # .

Changes proposed in this PR:

- use ocean.js@3.0.3 with nonce updates