### PR TITLE
bump oceanjs lib

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@coingecko/cryptoformat": "^0.5.4",
         "@loadable/component": "^5.15.2",
         "@oceanprotocol/art": "^3.2.0",
-        "@oceanprotocol/lib": "^3.0.3",
+        "@oceanprotocol/lib": "^3.0.4",
         "@oceanprotocol/typographies": "^0.1.0",
         "@oceanprotocol/use-dark-mode": "^2.4.3",
         "@orbisclub/orbis-sdk": "^0.4.40",
@@ -6081,9 +6081,9 @@
       "integrity": "sha512-PJih7C6LHaWHHj1qgxZsSkEqKphhJrL3G7WuMOxl4N1daDrF6sooDDU+9dZkcHSVPc7cMjkFqLc5fP58NSAobw=="
     },
     "node_modules/@oceanprotocol/lib": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@oceanprotocol/lib/-/lib-3.0.3.tgz",
-      "integrity": "sha512-e4O3C5+Gw16FPkXJyE4cgspSnc7615lKg3VDiSarG10HDBt9WVmniyI9i03wYFwjz4R7op8O8EtF9OQnXWfd6g==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@oceanprotocol/lib/-/lib-3.0.4.tgz",
+      "integrity": "sha512-HG187KtiT6LV8N5RbupcdKMR+6qsYLEmf43H5gnrIjDflachSayc1R629M7FPC29M8RMgqhfCwKLJJN64U+pmw==",
       "dependencies": {
         "@oceanprotocol/contracts": "^1.1.14",
         "cross-fetch": "^3.1.5",
@@ -58451,9 +58451,9 @@
       "integrity": "sha512-PJih7C6LHaWHHj1qgxZsSkEqKphhJrL3G7WuMOxl4N1daDrF6sooDDU+9dZkcHSVPc7cMjkFqLc5fP58NSAobw=="
     },
     "@oceanprotocol/lib": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@oceanprotocol/lib/-/lib-3.0.3.tgz",
-      "integrity": "sha512-e4O3C5+Gw16FPkXJyE4cgspSnc7615lKg3VDiSarG10HDBt9WVmniyI9i03wYFwjz4R7op8O8EtF9OQnXWfd6g==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@oceanprotocol/lib/-/lib-3.0.4.tgz",
+      "integrity": "sha512-HG187KtiT6LV8N5RbupcdKMR+6qsYLEmf43H5gnrIjDflachSayc1R629M7FPC29M8RMgqhfCwKLJJN64U+pmw==",
       "requires": {
         "@oceanprotocol/contracts": "^1.1.14",
         "cross-fetch": "^3.1.5",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@coingecko/cryptoformat": "^0.5.4",
     "@loadable/component": "^5.15.2",
     "@oceanprotocol/art": "^3.2.0",
-    "@oceanprotocol/lib": "^3.0.3",
+    "@oceanprotocol/lib": "^3.0.4",
     "@oceanprotocol/typographies": "^0.1.0",
     "@oceanprotocol/use-dark-mode": "^2.4.3",
     "@orbisclub/orbis-sdk": "^0.4.40",


### PR DESCRIPTION
Fixes # .

Changes proposed in this PR:

- use ocean.js 3.0.4 that removes head request in download file browser helper
- 
- 