### PR TITLE
fix: free assets not displayed in c2d

### DIFF
--- a/src/@utils/assetConvertor.ts
+++ b/src/@utils/assetConvertor.ts
@@ -14,7 +14,7 @@ export async function transformAssetToAssetSelection(
       getServiceByName(asset, 'compute') || getServiceByName(asset, 'access')
 
     if (
-      asset?.stats?.price?.value &&
+      asset?.stats?.price?.value >= 0 &&
       algoService?.serviceEndpoint === datasetProviderEndpoint
     ) {
       let selected = false

--- a/src/components/Asset/AssetActions/Compute/index.tsx
+++ b/src/components/Asset/AssetActions/Compute/index.tsx
@@ -498,20 +498,14 @@ export default function Compute({
       </div>
 
       {isUnsupportedPricing ? null : asset.metadata.type === 'algorithm' ? (
-        <>
-          {asset.services[0].type === 'compute' && (
-            <Alert
-              text={
-                "This algorithm has been set to private by the publisher and can't be downloaded. You can run it against any allowed datasets though!"
-              }
-              state="info"
-            />
-          )}
-          <AlgorithmDatasetsListForCompute
-            algorithmDid={asset.id}
-            asset={asset}
+        asset.services[0].type === 'compute' && (
+          <Alert
+            text={
+              "This algorithm has been set to private by the publisher and can't be downloaded. You can run it against any allowed datasets though!"
+            }
+            state="info"
           />
-        </>
+        )
       ) : (
         <Formik
           initialValues={getInitialValues(asset, selectedAlgorithmAsset)}


### PR DESCRIPTION
Fixes #1964

Changes proposed in this PR:

- fix: free algorithms are not displayed in the edit compute section
- fix: free algorithms are not available in the algorithm selection list for datasets with "allow all algorithms" set to `true`
- remove `AssetSelection` component from algorithm c2d actions