### PR TITLE
restore error check on custom params inputs

### DIFF
--- a/src/components/@shared/FormInput/index.tsx
+++ b/src/components/@shared/FormInput/index.tsx
@@ -77,16 +77,16 @@ function checkError(
   parsedFieldName: string[],
   field: FieldInputProps<any>
 ) {
-  if (
-    (form?.touched?.[parsedFieldName[0]]?.[parsedFieldName[1]] &&
-      form?.errors?.[parsedFieldName[0]]?.[parsedFieldName[1]]) ||
-    (form?.touched[field?.name] &&
-      form?.errors[field?.name] &&
-      field.name !== 'files' &&
-      field.name !== 'links')
-  ) {
-    return true
-  }
+  const touched = getObjectPropertyByPath(form?.touched, field?.name)
+  const errors = getObjectPropertyByPath(form?.errors, field?.name)
+
+  return (
+    touched &&
+    errors &&
+    !field.name.endsWith('.files') &&
+    !field.name.endsWith('.links') &&
+    !field.name.endsWith('consumerParameters')
+  )
 }
 
 export default function Input(props: Partial<InputProps>): ReactElement {


### PR DESCRIPTION
- Fixes #1979 .

Changes proposed in this PR:

- restore customer parameter error check


**HOW TO TEST:**

Publish:
- Go to Publish
- Select "Algorith" asset type
- Complete the rest in the form
- Check this "This asset uses algorithm custom parameters"
- Add, test, review custom parameters' fields

Edit:
- Go to an asset with custom parameters you had published
- Click on "Edit"
- Add, remove, test, review custom parameters
- Save changes 