### PR TITLE
Normalize url to validate the endpoint

### DIFF
--- a/src/@utils/assetConvertor.ts
+++ b/src/@utils/assetConvertor.ts
@@ -1,6 +1,7 @@
 import { PublisherTrustedAlgorithm, Asset } from '@oceanprotocol/lib'
 import { AssetSelectionAsset } from '@shared/FormInput/InputElement/AssetSelection'
 import { getServiceByName } from './ddo'
+import normalizeUrl from 'normalize-url'
 
 export async function transformAssetToAssetSelection(
   datasetProviderEndpoint: string,
@@ -15,7 +16,8 @@ export async function transformAssetToAssetSelection(
 
     if (
       asset?.stats?.price?.value >= 0 &&
-      algoService?.serviceEndpoint === datasetProviderEndpoint
+      normalizeUrl(algoService?.serviceEndpoint) ===
+        normalizeUrl(datasetProviderEndpoint)
     ) {
       let selected = false
       selectedAlgorithms?.forEach((algorithm: PublisherTrustedAlgorithm) => {


### PR DESCRIPTION
Fixes #1990 

To test it out, you can use this asset: did:op:94a2c281b6b0a09067310c77c5d49c3610b5ead5a31157f65f2c84022a1bc32e 

On the [market]( https://market.oceanprotocol.com/asset/did:op:94a2c281b6b0a09067310c77c5d49c3610b5ead5a31157f65f2c84022a1bc32e) the algo list has 2 items
On the [Preview](https://market-git-feature-normalizeurl-oceanprotocol.vercel.app/asset/did:op:94a2c281b6b0a09067310c77c5d49c3610b5ead5a31157f65f2c84022a1bc32e) has 5 items