### PR TITLE
Updating validation so that node or python images can be selected

### DIFF
--- a/src/components/Publish/_validation.ts
+++ b/src/components/Publish/_validation.ts
@@ -31,11 +31,17 @@ const validationMetadata = {
   }),
   dockerImageCustomChecksum: Yup.string().when('type', {
     is: 'algorithm',
-    then: Yup.string().required('Required')
+    then: Yup.string().when('dockerImage', {
+      is: 'custom',
+      then: Yup.string().required('Required')
+    })
   }),
   dockerImageCustomEntrypoint: Yup.string().when('type', {
     is: 'algorithm',
-    then: Yup.string().required('Required')
+    then: Yup.string().when('dockerImage', {
+      is: 'custom',
+      then: Yup.string().required('Required')
+    })
   }),
   termsAndConditions: Yup.boolean()
     .required('Required')


### PR DESCRIPTION
Fixes #1998

Changes proposed in this PR:

- Updating the validation so that the custom input checks only happen if custom image has been selected. 