### PR TITLE
Only validating custom parameters if algorithm has been selected

### DIFF
--- a/src/components/Publish/_validation.ts
+++ b/src/components/Publish/_validation.ts
@@ -41,14 +41,17 @@ const validationMetadata = {
     .required('Required')
     .isTrue('Please agree to the Terms and Conditions.'),
   usesConsumerParameters: Yup.boolean(),
-  consumerParameters: Yup.array().when('usesConsumerParameters', {
-    is: true,
-    then: Yup.array()
-      .of(Yup.object().shape(validationConsumerParameters))
-      .required('Required'),
-    otherwise: Yup.array()
-      .nullable()
-      .transform((value) => value || null)
+  consumerParameters: Yup.array().when('type', {
+    is: 'algorithm',
+    then: Yup.array().when('usesConsumerParameters', {
+      is: true,
+      then: Yup.array()
+        .of(Yup.object().shape(validationConsumerParameters))
+        .required('Required'),
+      otherwise: Yup.array()
+        .nullable()
+        .transform((value) => value || null)
+    })
   })
 }
 


### PR DESCRIPTION
Fixes #2003 

Changes proposed in this PR:

- Only validating custom parameters if `algorithm` has been selected